### PR TITLE
update tasks to use the new preferred looping syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,10 @@
 
 - name: Install WireGuard
   package:
-    name: "{{ item }}"
+    name: "{{ packages }}"
     state: present
-  with_items:
+  vars:
+    packages:
     - wireguard-dkms
     - wireguard-tools
   tags:

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -1,10 +1,11 @@
 ---
 - name: Install required packages
   pacman:
-    name: "{{ item }}"
+    name: "{{ packages }}"
     state: present
   become: yes
-  with_items:
-    - linux-headers
+  vars:
+    packages:
+      - linux-headers
   tags:
     - wg-install

--- a/tasks/setup-ubuntu.yml
+++ b/tasks/setup-ubuntu.yml
@@ -8,9 +8,10 @@
 
 - name: Install required packages
   package:
-    name: "{{ item }}"
+    name: "{{ packages }}"
     state: present
-  with_items:
+  vars:
+    packages:
     - software-properties-common
     - linux-headers-{{ ansible_kernel }}
   tags:


### PR DESCRIPTION
As per the [ansible loop docs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#iterating-over-a-simple-list) it is preferred to use this new syntax where possible instead of `loop` or `with_items`

> You can pass a list directly to a parameter for some plugins. Most of the packaging modules, like yum – Manages packages with the yum package manager and apt – Manages apt-packages, have this capability. When available, passing the list to a parameter is better than looping over the task. 