### PR TITLE
Add interface options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ I tag every release and try to stay with [semantic versioning](http://semver.org
 Requirements
 ------------
 
-By default port `51820` (protocol UDP) should be accessable from the outside. But you can adjust the port by changing the variable `wireguard_port`. Also IP forwarding needs to be enabled. This can be done by setting `wireguard_ip_forward: true`. But IMHO that should be handled elsewhere in a dedicated role that handles all security related things (but that's maybe a philosophical question ;-) ). You can use my [ansible-role-harden-linux](https://github.com/githubixx/ansible-role-harden-linux) e.g. Besides changing `sysctl` entries (which you need to enable IP forwarding) it also manages firewall settings among other things.
+By default port `51820` (protocol UDP) should be accessable from the outside. But you can adjust the port by changing the variable `wireguard_port`. Also IP forwarding needs to be enabled e.g. via `echo 1 > /proc/sys/net/ipv4/ip_forward `. I decided not to implement this task in this Ansible role. IMHO that should be handled elsewhere. You can use my [ansible-role-harden-linux](https://github.com/githubixx/ansible-role-harden-linux) e.g. Besides changing sysctl entries (which you need to enable IP forwarding) it also manages firewall settings among other things.
 
 Changelog
 ---------
@@ -38,13 +38,6 @@ wireguard_port: "51820"
 
 # The default interface name that wireguard should use if not specified otherwise.
 wireguard_interface: "wg0"
-
-# Enable IP forwarding between hosts. Set to "false" by default to keep
-# the role backwards compatible. Also this may not be the right place
-# to enable IP forwarding if you have a dedicated role that manages 
-# security related settings like this or firewalls in general e.g. But it
-# may be useful for some people.
-wireguard_ip_forward: false
 ```
 
 The following variable is mandatory and needs to be configured for every host in `host_vars/`:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ I tag every release and try to stay with [semantic versioning](http://semver.org
 Requirements
 ------------
 
-By default port `51820` (protocol UDP) should be accessable from the outside. But you can adjust the port by changing the variable `wireguard_port`. Also IP forwarding needs to be enabled e.g. via `echo 1 > /proc/sys/net/ipv4/ip_forward `. I decided not to implement this task in this Ansible role. IMHO that should be handled elsewhere. You can use my [ansible-role-harden-linux](https://github.com/githubixx/ansible-role-harden-linux) e.g. Besides changing sysctl entries (which you need to enable IP forwarding) it also manages firewall settings among other things.
+By default port `51820` (protocol UDP) should be accessable from the outside. But you can adjust the port by changing the variable `wireguard_port`. Also IP forwarding needs to be enabled. This can be done by setting `wireguard_ip_forward: true`. But IMHO that should be handled elsewhere in a dedicated role that handles all security related things (but that's maybe a philosophical question ;-) ). You can use my [ansible-role-harden-linux](https://github.com/githubixx/ansible-role-harden-linux) e.g. Besides changing `sysctl` entries (which you need to enable IP forwarding) it also manages firewall settings among other things.
 
 Changelog
 ---------
@@ -38,6 +38,13 @@ wireguard_port: "51820"
 
 # The default interface name that wireguard should use if not specified otherwise.
 wireguard_interface: "wg0"
+
+# Enable IP forwarding between hosts. Set to "false" by default to keep
+# the role backwards compatible. Also this may not be the right place
+# to enable IP forwarding if you have a dedicated role that manages 
+# security related settings like this or firewalls in general e.g. But it
+# may be useful for some people.
+wireguard_ip_forward: false
 ```
 
 The following variable is mandatory and needs to be configured for every host in `host_vars/`:

--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@ Endpoint = controller01.p.domain.tld:51820
 
 Now this is basically the same as above BUT now the config says: I want to route EVERY traffic originating from my workstation to the endpoint `controller01.p.domain.tld:51820`. If that endpoint can handle the traffic is of course another thing and it's up to you how you configure the endpoint routing ;-)
 
-You can specify further optional settings (they don't have a default and won't be set if not specified besides `wireguard_allowed_ips` as already mentioned) also per host in `host_vars/` (or in your Ansible hosts file if you like):
+You can specify further optional settings (they don't have a default and won't be set if not specified besides `wireguard_allowed_ips` as already mentioned) also per host in `host_vars/` (or in your Ansible hosts file if you like). The values for the following variables are just examples and no defaults (for more information and examples see [wg-quick.8](https://git.zx2c4.com/WireGuard/about/src/tools/man/wg-quick.8)):
 
 ```
 wireguard_allowed_ips: ""
 wireguard_endpoint: "host1.domain.tld"
 wireguard_persistent_keepalive: "30"
 wireguard_dns: "1.1.1.1"
+wireguard_fwmark: "1234"
+wireguard_mtu: "1492"
+wireguard_table: "5000"
+wireguard_preup: "..."
+wireguard_predown: "..."
 wireguard_postup: "..."
 wireguard_postdown: "..."
 wireguard_save_config: "true"
@@ -259,6 +264,7 @@ vpn1:
       wireguard_endpoint: nated.exemple.com
       wireguard_postup: "iptables -t nat -A POSTROUTING -o ens12 -j MASQUERADE"
       wireguard_postdown: "iptables -t nat -D POSTROUTING -o ens12 -j MASQUERADE"
+
 vpn2:
   hosts:
     multi-wg1: # use a different name, and define ansible_host, to avoid mixing of vars without needing to prefix vars with interface name

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ see [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob/mast
 Role Variables
 --------------
 
-Those variables can be changed in `group_vars/`:
+These variables can be changed in `group_vars/`:
 
 ```
 # Directory to store WireGuard configuration on the remote hosts

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -6,6 +6,21 @@ ListenPort = {{wireguard_port}}
 {% if hostvars[inventory_hostname].wireguard_dns is defined %}
 DNS = {{hostvars[inventory_hostname].wireguard_dns}}
 {% endif %}
+{% if hostvars[inventory_hostname].wireguard_fwmark is defined %}
+FwMark = {{hostvars[inventory_hostname].wireguard_fwmark}}
+{% endif %}
+{% if hostvars[inventory_hostname].wireguard_mtu is defined %}
+MTU = {{hostvars[inventory_hostname].wireguard_mtu}}
+{% endif %}
+{% if hostvars[inventory_hostname].wireguard_table is defined %}
+Table = {{hostvars[inventory_hostname].wireguard_table}}
+{% endif %}
+{% if hostvars[inventory_hostname].wireguard_preup is defined %}
+PreUp = {{hostvars[inventory_hostname].wireguard_preup}}
+{% endif %}
+{% if hostvars[inventory_hostname].wireguard_predown is defined %}
+PreDown = {{hostvars[inventory_hostname].wireguard_predown}}
+{% endif %}
 {% if hostvars[inventory_hostname].wireguard_postup is defined %}
 PostUp = {{hostvars[inventory_hostname].wireguard_postup}}
 {% endif %}

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -1,5 +1,6 @@
 #jinja2: lstrip_blocks:"True",trim_blocks:"True"
 [Interface]
+# {{ inventory_hostname }}
 Address = {{hostvars[inventory_hostname].wireguard_address}}
 PrivateKey = {{private_key}}
 ListenPort = {{wireguard_port}}
@@ -34,6 +35,7 @@ SaveConfig = true
   {% if host != inventory_hostname %}
   
     [Peer]
+    # {{ host }}
     PublicKey = {{hostvars[host].public_key}}
     {% if hostvars[host].wireguard_allowed_ips is defined %}
     AllowedIPs = {{hostvars[host].wireguard_allowed_ips}}
@@ -52,7 +54,7 @@ SaveConfig = true
     {% elif hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "" %}
     Endpoint = {{hostvars[host].wireguard_endpoint}}:{{wireguard_port}}
     {% elif hostvars[host].wireguard_endpoint == "" %}
-    # No endpoint defined
+    # No endpoint defined for this peer
     {% else %}
     Endpoint = {{host}}:{{wireguard_port}}
     {% endif %}


### PR DESCRIPTION
- Allow to specifiy additional Wireguard interface options: `fwmark`, `mtu`, `table`, `preup` and `predown`
- Add host comments in Wireguard config file