### PR TITLE
Install GPG to be able to import WireGuard key

### DIFF
--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -9,6 +9,11 @@
   tags:
     - wg-install
 
+- name: Install GPG - required to add wireguard key
+  apt:
+    name: gpg
+    state: present
+
 - name: Add WireGuard key
   apt_key:
     keyserver: "keyserver.ubuntu.com"


### PR DESCRIPTION
I encountered an error when running the WireGuard role (as first role) on a Debian machine. Since I think this is part of the pre-conditions of this module, I think this should be added here.

![Screenshot from 2019-11-11 14-35-47](https://user-images.githubusercontent.com/199058/68591338-cd09e180-0490-11ea-91a2-a970e30a1c2b.png)
