### PR TITLE
Add basic fedora support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+**4.2.0**
+
+- Add support for Fedora (contribution by @ties)
+
+
 **4.1.1**
 
 - Install GPG to be able to import WireGuard key (Debian)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,9 @@ galaxy_info:
   - name: EL
     versions:
     - 7
+  - name: Fedora
+    versions:
+    - 31
   galaxy_tags:
     - networking
     - security

--- a/tasks/setup-fedora.yml
+++ b/tasks/setup-fedora.yml
@@ -1,0 +1,8 @@
+---
+  - name: Add wireguard COPR
+    yum_repository:
+      name: "jdoss-wireguard"
+      description: "Copr repo for wireguard owned by jdoss"
+      baseurl: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/fedora-$releasever-$basearch/"
+      gpgkey: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/pubkey.gpg"
+      gpgcheck: yes


### PR DESCRIPTION
This seems to be enough to enable wireguard on my fedora machine.