### PR TITLE
Allow to add peers to wg interfaces without taking them offline

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,5 @@
   service:
     name: "wg-quick@{{ wireguard_interface }}"
     state: restarted
+- name: start/reload wireguard
+  command: "bash -c 'systemctl start wg-quick@{{ wireguard_interface }}; wg syncconf {{ wireguard_interface}} <(wg-quick strip /etc/wireguard/{{ wireguard_interface }}.conf)'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,7 @@
   tags:
     - wg-config
   notify:
-    - restart wireguard
+    - start/reload wireguard
 
 - name: Check if reload-module-on-update is set
   stat:


### PR DESCRIPTION
Existing connections to peers should not be impaired when adding new peers. This PR implements online config sync for wireguard to allow just that.