### PR TITLE
Ability to create multiple postup/postdown/preup/predown commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,14 @@ vpn1:
       wireguard_allowed_ips: "10.9.0.2/32, 192.168.3.0/24"
       wireguard_persistent_keepalive: 15
       wireguard_endpoint: nated.exemple.com
-      wireguard_postup: "iptables -t nat -A POSTROUTING -o ens12 -j MASQUERADE"
-      wireguard_postdown: "iptables -t nat -D POSTROUTING -o ens12 -j MASQUERADE"
+      wireguard_postup:
+        - iptables -t nat -A POSTROUTING -o ens12 -j MASQUERADE
+        - iptables -A FORWARD -i %i -j ACCEPT
+        - iptables -A FORWARD -o %i -j ACCEPT
+      wireguard_postdown:
+        - iptables -t nat -D POSTROUTING -o ens12 -j MASQUERADE
+        - iptables -D FORWARD -i %i -j ACCEPT
+        - iptables -D FORWARD -o %i -j ACCEPT
 
 vpn2:
   hosts:

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -17,16 +17,24 @@ MTU = {{hostvars[inventory_hostname].wireguard_mtu}}
 Table = {{hostvars[inventory_hostname].wireguard_table}}
 {% endif %}
 {% if hostvars[inventory_hostname].wireguard_preup is defined %}
-PreUp = {{hostvars[inventory_hostname].wireguard_preup}}
+{% for wg_preup in hostvars[inventory_hostname].wireguard_preup %}
+PreUp = {{ wg_preup }}
+{% endfor %}
 {% endif %}
 {% if hostvars[inventory_hostname].wireguard_predown is defined %}
-PreDown = {{hostvars[inventory_hostname].wireguard_predown}}
+{% for wg_predown in hostvars[inventory_hostname].wireguard_predown %}
+PreDown = {{ wg_predown }}
+{% endfor %}
 {% endif %}
 {% if hostvars[inventory_hostname].wireguard_postup is defined %}
-PostUp = {{hostvars[inventory_hostname].wireguard_postup}}
+{% for wg_postup in hostvars[inventory_hostname].wireguard_postup %}
+PostUp = {{ wg_postup }}
+{% endfor %}
 {% endif %}
 {% if hostvars[inventory_hostname].wireguard_postdown is defined %}
-PostDown = {{hostvars[inventory_hostname].wireguard_postdown}}
+{% for wg_postdown in hostvars[inventory_hostname].wireguard_postdown %}
+PostDown = {{ wg_postdown }}
+{% endfor %}
 {% endif %}
 {% if hostvars[inventory_hostname].wireguard_save_config is defined %}
 SaveConfig = true


### PR DESCRIPTION
Often, more than one iptables command is required for a meaningful firewall setup. Of course we can just append all commands with '&&' but that isn't readable depending on the amount of commands.

With this pull request, multiple  postup/postdown/preup/predown commands are created if specified