### PR TITLE
Bugfix: Install gnupg instead of gpg for Debian

### DIFF
--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -11,7 +11,7 @@
 
 - name: Install GPG - required to add wireguard key
   apt:
-    name: gpg
+    name: gnupg
     state: present
 
 - name: Add WireGuard key


### PR DESCRIPTION
I was getting the following error _on the second run_ when attempting to use this role to provision a Wireguard server on Debian 9.12.

```
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 gpg : Depends: gpgconf (= 2.2.19-3) but it is not going to be installed
       Depends: libassuan0 (>= 2.5.0) but 2.4.3-2 is to be installed
       Depends: libc6 (>= 2.25) but 2.24-1
1+deb9u4 is to be installed
       Depends: libgcrypt20 (>= 1.8.0) but 1.7.6-2+deb9u3 is to be installed
       Depends: libgpg-error0 (>= 1.35) but 1.26-2 is to be installed
       Recommends: gnupg (= 2.2.19-3) but it is not going to be installed
```

I spun up another machine and started running commands locally and noticed that it seemed like apt decided to download `gnupg` instead of `gpg` on the first run and then the second time through I would get the error.

I made this change and now I can run the role multiple times and the wireguard server seems to work.