### PR TITLE
Forcing stop and start to clear routes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,10 @@
 - name: restart wireguard
   service:
     name: "wg-quick@{{ wireguard_interface }}"
-    state: restarted
+    state: "{{ item }}"
+  loop:
+  - stopped
+  - started
   when: not wg_syncconf
   listen: "reconfigure wireguard"
 


### PR DESCRIPTION
Rationale:
- At least on Ubuntu 18.04, if running this role multiple times, additional routes are not being set
- A full stop and start works well, compared to just a service restart
