### PR TITLE
Use Arch Linux specific package list

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,14 +4,20 @@
 
 - include_tasks: "setup-{{ ansible_distribution|lower }}.yml"
 
+- name: Load packages variable file based on the OS type, or a default if not found
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "packages-{{ ansible_distribution | lower }}.yml"
+        - "packages.yml"
+      paths:
+        - "vars"
+
 - name: Install WireGuard
   package:
     name: "{{ packages }}"
     state: present
-  vars:
-    packages:
-    - wireguard-dkms
-    - wireguard-tools
   tags:
     - wg-install
 

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -1,11 +1,23 @@
 ---
-- name: Install required packages
+- name: Install wireguard-lts package
   pacman:
-    name: "{{ packages }}"
-    state: present
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+  with_items:
+    - { name: wireguard-dkms, state: absent }
+    - { name: wireguard-lts, state: present }
   become: yes
-  vars:
-    packages:
-      - linux-headers
   tags:
     - wg-install
+  when:
+    - ansible_kernel is match(".*-lts$")
+    - ansible_kernel is version('5.6', '<')
+- name: Install wireguard-dksm package
+  pacman:
+    name: wireguard-dkms
+  become: yes
+  tags:
+    - wg-install
+  when:
+    - not ansible_kernel is match(".*-lts$")
+    - ansible_kernel is version('5.6', '<')

--- a/vars/packages-archlinux.yml
+++ b/vars/packages-archlinux.yml
@@ -1,0 +1,2 @@
+packages:
+  - wireguard-tools

--- a/vars/packages.yml
+++ b/vars/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - wireguard-dkms
+  - wireguard-tools


### PR DESCRIPTION
Arch Linux ships a Linux kernel > 5.6 and doesn't require DKMS.

Move the package list variable to (distribution-specific) var files.

For the Arch Linux LTS kernel (5.4) a binary wireguard-lts package is
provided in [core].