### PR TITLE
Use wireguard from buster-backports on debian if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 ---------
 
-*6.0.4*
+**6.0.4**
 
 - Use the buster-backports repository on Debian Buster (or older), use package
   standard repositories on sid/bullseye.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+*6.0.4*
+
+- Use the buster-backports repository on Debian Buster (or older), use package
+  standard repositories on sid/bullseye.
+
 **6.0.3**
 
 - If `wg syncconf` command is not available do stop/start service instead of restart (contribution by @cristichiru)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Changelog
 - Use the buster-backports repository on Debian Buster (or older), use package
   standard repositories on sid/bullseye.
 
+  The role no longer adds the unstable _repo_ nor the _apt preference_ for that repo.
+  There is no need to clean the preference and unstable repository, since packages
+  from your release have a higher priority.
+
+  If you remove the apt preference (`/etc/apt/preferences.d/limit-unstable`)
+  updates from `unstable` are accepted by apt. This likely is not what you want
+  and may lead to an unstable state.
+
+  If you want to clean up:
+    * remove `/etc/apt/preferences.d/limit-unstable` and
+    * remove `deb http://deb.debian.org/debian/ unstable main` from `/etc/apt/sources.list.d/deb_debian_org_debian.list`.
+
+  The backports repository has a lower priority and does not need an apt preference.
+
 **6.0.3**
 
 - If `wg syncconf` command is not available do stop/start service instead of restart (contribution by @cristichiru)

--- a/files/debian/etc/apt/preferences.d/limit-unstable
+++ b/files/debian/etc/apt/preferences.d/limit-unstable
@@ -1,3 +1,0 @@
-Package: *
-Pin: release a=unstable
-Pin-Priority: 90

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -14,17 +14,9 @@
     name: gnupg
     state: present
 
-- name: Add WireGuard key
-  apt_key:
-    keyserver: "keyserver.ubuntu.com"
-    id: "8B48AD6246925553"
-    state: present
-  tags:
-    - wg-install
-
 - name: Add WireGuard repository
   apt_repository:
-    repo: "deb http://deb.debian.org/debian/ unstable main"
+    repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
     update_cache: yes
   tags:

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -1,14 +1,4 @@
 ---
-- name: Setup WireGuard preference
-  copy:
-    src: debian/etc/apt/preferences.d/limit-unstable
-    dest: /etc/apt/preferences.d/limit-unstable
-    owner: root
-    group: root
-    mode: 0644
-  tags:
-    - wg-install
-
 - name: Install GPG - required to add wireguard key
   apt:
     name: gnupg

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -14,11 +14,12 @@
     name: gnupg
     state: present
 
-- name: Add WireGuard repository
+- name: Add WireGuard repository on buster or earlier
   apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
     update_cache: yes
+  when: ansible_distribution_version | int <= 10
   tags:
     - wg-install
 


### PR DESCRIPTION
I found out that my changes to add debian support no longer worked.

  * Wireguard key was missing from keyserver and no longer needed to be added for buster-backports.
  * `buster-backports` contains wireguard, using this for <= buster
  * no longer pin packages from `unstable`. No need to pin backports, it has a lower priority than main repo.

