### PR TITLE
Support Ubuntu 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+**6.2.0**
+
+- Support Ubuntu 20.04 (Focal Fossa)
+- Introduce `wireguard_ubuntu_update_cache` and `wireguard_ubuntu_cache_valid_time` variables to specifiy individual Ubuntu package cache settings. Default values are the same as before.
+
 **6.1.0**
 
 - Archlinux: Linux kernel >= 5.6 contains `wireguard` module now. No need to install `wireguard-dkms` anymore in this case. Installations with LTS kernel installs `wireguard-lts` package now instead of `wireguard-dkms`. Installations with kernel <= 5.6 will still install `wireguard-dkms` package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 - Support Ubuntu 20.04 (Focal Fossa)
 - Introduce `wireguard_ubuntu_update_cache` and `wireguard_ubuntu_cache_valid_time` variables to specifiy individual Ubuntu package cache settings. Default values are the same as before.
+- As kernel >= 5.6 (and kernel 5.4 in Ubuntu 20.04) now have `wireguard` module included `wireguard-dkms` package is no longer needed in that case. That's why WireGuard package installation is now part of the includes for the specific OS to make it easier to handle various cases.
 
 **6.1.0**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I used [PeerVPN](https://peervpn.net/) before but that wasn't updated for a whil
 
 In general WireGuard is a network tunnel (VPN) for IPv4 and IPv6 that uses UDP. If you need more information about [WireGuard](https://www.wireguard.io/) you can find a good introduction here: [Installing WireGuard, the Modern VPN](https://research.kudelskisecurity.com/2017/06/07/installing-wireguard-the-modern-vpn/).
 
-This role was tested with Ubuntu 18.04 (Bionic Beaver), Debian 9 (Stretch), Archlinux, Fedora 31 and CentOS. It might also work with Ubuntu 16.04 (Xenial Xerus), Debian 10 (Buster) or other distributions but haven't tested it. If someone tested it let me please know if it works or send a pull request to make it work ;-)
+This role is tested with Ubuntu 18.04 (Bionic Beaver), Ubuntu 20 (Focal Fossa) and Archlinux. Ubuntu 16.04 (Xenial Xerus), Debian 9 (Stretch), Debian 10 (Buster), Fedora 31 (or later) and CentOS 7 might also work or other distributions but haven't tested it (code for this operating systems was submitted by other contributors). If someone tested it let me please know if it works or send a pull request to make it work ;-)
 
 Versions
 --------
@@ -294,11 +294,13 @@ vpn1:
 
 vpn2:
   hosts:
-    # use a different name, and define ansible_host, to avoid mixing of vars without needing to prefix vars with interface name
+    # Use a different name, and define ansible_host, to avoid mixing of vars without
+    # needing to prefix vars with interface name.
     multi-wg1:
       ansible_host: multi
       wireguard_interface: wg1
-      wireguard_port: 51821 # when using several interface on one host, we must use different ports
+      # when using several interface on one host, we must use different ports
+      wireguard_port: 51821
       wireguard_address: 10.9.1.1/32
       wireguard_endpoint: multi.exemple.com
     another:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+#######################################
+# General settings
+#######################################
+
 # Directory to store WireGuard configuration on the remote hosts
 wireguard_remote_directory: "/etc/wireguard"
 
@@ -7,3 +11,14 @@ wireguard_port: "51820"
 
 # The default interface name that wireguard should use if not specified otherwise.
 wireguard_interface: "wg0"
+
+
+#######################################
+# Settings only relevant for Ubuntu
+#######################################
+
+# Set to "false" if package cache should not be updated
+wireguard_ubuntu_update_cache: "true"
+
+# Set package cache valid time
+wireguard_ubuntu_cache_valid_time: "3600"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,9 +8,11 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - bionic
+    - focal
   - name: Debian
     versions:
     - stretch
+    - buster
   - name: EL
     versions:
     - 7

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,23 +4,6 @@
 
 - include_tasks: "setup-{{ ansible_distribution|lower }}.yml"
 
-- name: Load packages variable file based on the OS type, or a default if not found
-  include_vars: "{{ lookup('first_found', params) }}"
-  vars:
-    params:
-      files:
-        - "packages-{{ ansible_distribution | lower }}.yml"
-        - "packages.yml"
-      paths:
-        - "vars"
-
-- name: Install WireGuard
-  package:
-    name: "{{ packages }}"
-    state: present
-  tags:
-    - wg-install
-
 - name: Enable WireGuard kernel module
   modprobe:
     name: wireguard
@@ -48,6 +31,7 @@
 - name: Get wg subcommands
   command: "wg --help"
   register: wg_subcommands
+  changed_when: false
 
 - name: Set default value for wg_syncconf variable (assume wg syncconf subcommand not available)
   set_fact:
@@ -64,8 +48,9 @@
 
 - block:
   - name: Generate WireGuard private key
-    shell: "wg genkey"
+    command: "wg genkey"
     register: wg_private_key_result
+    changed_when: false
     tags:
       - wg-generate-keys
 

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install wireguard-lts package
+- name: (Archlinux) Install wireguard-lts package
   pacman:
     name: "{{ item.name }}"
     state: "{{ item.state }}"
@@ -13,12 +13,20 @@
     - ansible_kernel is match(".*-lts$")
     - ansible_kernel is version('5.6', '<')
 
-- name: Install wireguard-dkms package
+- name: (Archlinux) Install wireguard-dkms package
   pacman:
     name: wireguard-dkms
+    state: present
   become: yes
   tags:
     - wg-install
   when:
     - not ansible_kernel is match(".*-lts$")
     - ansible_kernel is version('5.6', '<')
+
+- name: (Archlinux) Install wireguard-tools package
+  pacman:
+    name: wireguard-tools
+    state: present
+  tags:
+    - wg-install

--- a/tasks/setup-centos.yml
+++ b/tasks/setup-centos.yml
@@ -1,11 +1,19 @@
 ---
-
-- name: Add WireGuard repository
+- name: (CentOS) Add WireGuard repository
   get_url:
     url: https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
     dest: /etc/yum.repos.d/wireguard.repo
 
-- name: Install EPEL repository
+- name: (CentOS) Install EPEL repository
   yum:
     name: epel-release
     update_cache: yes
+
+- name: (CentOS) Install wireguard packages
+  yum:
+    name:
+      - "wireguard-dkms"
+      - "wireguard-tools"
+    state: present
+  tags:
+    - wg-install

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -1,10 +1,10 @@
 ---
-- name: Install GPG - required to add wireguard key
+- name: (Debian) Install GPG - required to add wireguard key
   apt:
     name: gnupg
     state: present
 
-- name: Add WireGuard repository on buster or earlier
+- name: (Debian) Add WireGuard repository on buster or earlier
   apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
@@ -13,13 +13,22 @@
   tags:
     - wg-install
 
-- name: Get architecture
-  shell: dpkg --print-architecture
+- name: (Debian) Get architecture
+  command: "dpkg --print-architecture"
   register: dpkg_arch
   changed_when: False
 
-- name: Install kernel headers to compile wireguard with DKMS
+- name: (Debian) Install kernel headers to compile Wireguard with DKMS
   apt:
     name:
       - "linux-headers-{{ dpkg_arch.stdout }}"
     state: present
+
+- name: (Debian) Install wireguard packages
+  apt:
+    name:
+      - "wireguard-dkms"
+      - "wireguard-tools"
+    state: present
+  tags:
+    - wg-install

--- a/tasks/setup-fedora.yml
+++ b/tasks/setup-fedora.yml
@@ -1,8 +1,17 @@
 ---
-  - name: Add wireguard COPR
-    yum_repository:
-      name: "jdoss-wireguard"
-      description: "Copr repo for wireguard owned by jdoss"
-      baseurl: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/fedora-$releasever-$basearch/"
-      gpgkey: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/pubkey.gpg"
-      gpgcheck: yes
+- name: (Fedora) Add wireguard COPR
+  yum_repository:
+    name: "jdoss-wireguard"
+    description: "Copr repo for wireguard owned by jdoss"
+    baseurl: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/fedora-$releasever-$basearch/"
+    gpgkey: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/pubkey.gpg"
+    gpgcheck: yes
+
+- name: (Fedora) Install wireguard packages
+  yum:
+    name:
+      - "wireguard-dkms"
+      - "wireguard-tools"
+    state: present
+  tags:
+    - wg-install

--- a/tasks/setup-ubuntu.yml
+++ b/tasks/setup-ubuntu.yml
@@ -1,26 +1,48 @@
 ---
-- name: Update APT package cache
+- name: (Ubuntu) Update APT package cache
   apt:
     update_cache: "{{ wireguard_ubuntu_update_cache }}"
     cache_valid_time: "{{ wireguard_ubuntu_cache_valid_time }}"
   tags:
     - wg-install
 
-- name: Install required packages
-  package:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-    - software-properties-common
-    - linux-headers-{{ ansible_kernel }}
-  tags:
-    - wg-install
+- block:
+  - name: (Ubuntu) Install support packages needed for Wireguard (for Ubuntu < 19.10)
+    package:
+      name: "{{ packages }}"
+      state: present
+    vars:
+      packages:
+      - software-properties-common
+      - linux-headers-{{ ansible_kernel }}
+    tags:
+      - wg-install
 
-- name: Add WireGuard repository
-  apt_repository:
-    repo: "ppa:wireguard/wireguard"
-    state: present
-    update_cache: yes
-  tags:
-    - wg-install
+  - name: (Ubuntu) Add WireGuard repository (for Ubuntu < 19.10)
+    apt_repository:
+      repo: "ppa:wireguard/wireguard"
+      state: present
+      update_cache: yes
+    tags:
+      - wg-install
+
+  - name: (Ubuntu) Install wireguard packages (for Ubuntu < 19.10)
+    apt:
+      name:
+        - "wireguard-dkms"
+        - "wireguard-tools"
+      state: present
+    tags:
+      - wg-install
+  when:
+    - ansible_lsb.major_release is version('19.10', '<')
+
+- block:
+  - name: (Ubuntu) Install wireguard-tools package (for Ubuntu > 19.04)
+    apt:
+      name: "wireguard-tools"
+      state: present
+    tags:
+      - wg-install
+  when:
+    - ansible_lsb.major_release is version('19.04', '>')

--- a/tasks/setup-ubuntu.yml
+++ b/tasks/setup-ubuntu.yml
@@ -1,8 +1,8 @@
 ---
 - name: Update APT package cache
   apt:
-    update_cache: true
-    cache_valid_time: 3600
+    update_cache: "{{ wireguard_ubuntu_update_cache }}"
+    cache_valid_time: "{{ wireguard_ubuntu_cache_valid_time }}"
   tags:
     - wg-install
 

--- a/vars/packages-archlinux.yml
+++ b/vars/packages-archlinux.yml
@@ -1,2 +1,0 @@
-packages:
-  - wireguard-tools

--- a/vars/packages.yml
+++ b/vars/packages.yml
@@ -1,3 +1,0 @@
-packages:
-  - wireguard-dkms
-  - wireguard-tools


### PR DESCRIPTION
- Support Ubuntu 20.04
- Add Debian Buster to Galaxy metadata
- Handle kernel's that already include "wireguard" module (that's mainly Archlinux and Ubuntu 20.04 at the moment)