### PR TITLE
Fix on debian openstack images

### DIFF
--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -21,8 +21,6 @@
 - set_fact:
     kernel_header_version: "{{ ('-cloud-' in ansible_kernel) | ternary(ansible_kernel,dpkg_arch.stdout) }}"
 
-- debug: msg="kernel_header_version {{ kernel_header_version }}"
-
 - name: (Debian) Install kernel headers to compile Wireguard with DKMS
   apt:
     name:

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -19,7 +19,9 @@
   changed_when: False
 
 - set_fact:
-    kernel_header_version: {{ '-cloud-' in ansible_kernel | ternary(ansible_kernel,dpkg_arch.stdout) }}
+    kernel_header_version: "{{ ('-cloud-' in ansible_kernel) | ternary(ansible_kernel,dpkg_arch.stdout) }}"
+
+- debug: msg="kernel_header_version {{ kernel_header_version }}"
 
 - name: (Debian) Install kernel headers to compile Wireguard with DKMS
   apt:

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -18,10 +18,16 @@
   register: dpkg_arch
   changed_when: False
 
+- name: (Debian) Get kernel version
+  command: "uname -r"
+  register: kernel_version
+  changed_when: False
+
 - name: (Debian) Install kernel headers to compile Wireguard with DKMS
   apt:
     name:
       - "linux-headers-{{ dpkg_arch.stdout }}"
+      - "linux-headers-{{ kernel_version.stdout }}"
     state: present
 
 - name: (Debian) Install wireguard packages


### PR DESCRIPTION
On openstack Debian images, the kernel is different, so we need to install different kernel headers, too.