### PR TITLE
Add wireguard_preshared_key variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**6.4.0**
+
+- Support specifying optional `wireguard_preshared_key` (contribution by @legogris)
+
 **6.3.1**
 
 - Support Openstack Debian images (contribution by @pallinger)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ wireguard_port: "51820"
 
 # The default interface name that wireguard should use if not specified otherwise.
 wireguard_interface: "wg0"
+
+# Preshared key to use for all peers (optional)
+wireguard_preshared_key: "abc123"
 ```
 
 The following variable is mandatory and needs to be configured for every host in `host_vars/`:

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -50,6 +50,9 @@ SaveConfig = true
     {% else %}
     AllowedIPs = {{hostvars[host].wireguard_ip}}/32
     {% endif %}
+    {% if wireguard_preshared_key is defined %}
+    PresharedKey = {{wireguard_preshared_key}}
+    {% endif %}
     {% if hostvars[host].wireguard_persistent_keepalive is defined %}
     PersistentKeepalive = {{hostvars[host].wireguard_persistent_keepalive}}
     {% endif %}


### PR DESCRIPTION
It could be desired to use a preshared key for additional security. This accommodates for that by an additional role variable `wireguard_preshared_key`.