### PR TITLE
Add basic macOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 ---------
+**7.2.0**
+
+- Basic MacOS X support (contribution by @rubendibattista)
 
 **7.1.0**
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ In general WireGuard is a network tunnel (VPN) for IPv4 and IPv6 that uses UDP. 
 
 This role is tested with Ubuntu 18.04 (Bionic Beaver), Ubuntu 20 (Focal Fossa) and Archlinux. Ubuntu 16.04 (Xenial Xerus), Debian 9 (Stretch), Debian 10 (Buster), Fedora 31 (or later) and CentOS 7 might also work or other distributions but haven't tested it (code for this operating systems was submitted by other contributors). If someone tested it let me please know if it works or send a pull request to make it work ;-)
 
+### Running the VPN on macOS
+While this playbook configures, enables and starts a `systemd` service on Linux in a such a way that no additional action is needed, on macOS it installs the required packages and it just generates the correct `wg0.conf` file that is then placed in the specified `wireguard_remote_directory` (`/opt/local/etc/wireguard` by default). In order to run the VPN, then, you need to: 
+
+```
+sudo wg-quick up wg0
+```
+
+and to deactivate it
+
+```
+sudo wg-quick down wg0
+```
+
+or you can install the [official app](https://apps.apple.com/it/app/wireguard/id1451685025?l=en&mt=12) and import the `wg0.conf` file. 
+
+
 Versions
 --------
 
@@ -31,7 +47,8 @@ These variables can be changed in `group_vars/`:
 
 ```yaml
 # Directory to store WireGuard configuration on the remote hosts
-wireguard_remote_directory: "/etc/wireguard"
+wireguard_remote_directory: "/etc/wireguard" # On Linux
+# wireguard_remote_directory: "/opt/local/etc/wireguard"  # On macOS
 
 # The default port WireGuard will listen if not specified otherwise.
 wireguard_port: "51820"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,13 +4,22 @@
 #######################################
 
 # Directory to store WireGuard configuration on the remote hosts
-wireguard_remote_directory: "/etc/wireguard"
+wireguard_remote_directory: "{{ '/etc/wireguard' if not ansible_os_family == 'Darwin' else '/opt/local/etc/wireguard' }}"
 
 # The default port WireGuard will listen if not specified otherwise.
 wireguard_port: "51820"
 
 # The default interface name that wireguard should use if not specified otherwise.
 wireguard_interface: "wg0"
+
+# The default owner of the wg.conf file
+wireguard_conf_owner: root
+
+# The default group of the wg.conf file
+wireguard_conf_group: "{{ 'root' if not ansible_os_family == 'Darwin' else 'wheel' }}"
+
+# The default mode of the wg.conf file
+wireguard_conf_mode: 0600
 
 
 #######################################

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,9 @@
   loop:
   - stopped
   - started
-  when: not wg_syncconf
+  when: >
+    not wg_syncconf and
+    not ansible_os_family == 'Darwin'
   listen: "reconfigure wireguard"
 
 - name: syncconf wireguard
@@ -19,5 +21,7 @@
       exit 0
   args:
     executable: "/bin/bash"
-  when: wg_syncconf
+  when: >
+    wg_syncconf and
+    not ansible_os_family == 'Darwin'
   listen: "reconfigure wireguard"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,17 +10,19 @@
     - "setup-{{ ansible_distribution|lower }}.yml"
     - "setup-{{ ansible_os_family|lower }}.yml"
 
-- name: Enable WireGuard kernel module
-  modprobe:
-    name: wireguard
-    state: present
-  register: wireguard_module_enabled
-  until:  wireguard_module_enabled is succeeded
-  retries: 10
-  delay: 10
-  failed_when: wireguard_module_enabled is failure
-  tags:
-    - wg-install
+- block:
+    - name: Enable WireGuard kernel module
+      modprobe:
+        name: wireguard
+        state: present
+      register: wireguard_module_enabled
+      until:  wireguard_module_enabled is succeeded
+      retries: 10
+      delay: 10
+      failed_when: wireguard_module_enabled is failure
+      tags:
+        - wg-install
+  when: not ansible_os_family == 'Darwin'
 
 - name: Set WireGuard IP (without mask)
   set_fact:
@@ -107,9 +109,9 @@
   template:
     src: wg.conf.j2
     dest: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
-    owner: root
-    group: root
-    mode: 0600
+    owner: "{{ wireguard_conf_owner }}"
+    group: "{{ wireguard_conf_group }}"
+    mode: "{{ wireguard_conf_mode }}"
   tags:
     - wg-config
   notify:
@@ -135,3 +137,4 @@
     name: "wg-quick@{{ wireguard_interface }}"
     state: started
     enabled: yes
+  when: not ansible_os_family == 'Darwin'

--- a/tasks/setup-macosx.yml
+++ b/tasks/setup-macosx.yml
@@ -1,0 +1,15 @@
+---
+- name: (MacOS) Install wireguard package
+  package:
+    name: wireguard-go
+    state: present
+  become: yes
+  tags:
+    - wg-install
+
+- name: (MacOS) Install wireguard-tools package
+  package:
+    name: wireguard-tools
+    state: present
+  tags:
+    - wg-install


### PR DESCRIPTION
I added basic support for `macOS`

- Add the `ansible_os_is_linux` internal variable to discern between a Linux system and a macOS one
- Conditional choice for `wireguard_remote_directory` default value. It defaults to `/etc/wireguard` on Linux and `/opt/local/etc/wireguard` (i.e. Macports default path) on macOS
- Add configurable `owner` and `group` for the configuration file `wg0.conf`. The group defaults on `wheel` on `macOS`
- No handlers for macOS 
- No kernel module activation on macOS
- Add instructions into the `README.md` on how to run the VPN on macOS manually