### PR TITLE
Add support for unmanaged WireGuard peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 **7.1.0**
 
-- Add support for unmanaged peers with `wireguard_extra_peer_config` (contribution by @joneskoo)
+- Add support for unmanaged peers with `wireguard_unmanaged_peers` (contribution by @joneskoo)
 
 **7.0.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 Changelog
 ---------
 
+**7.1.0**
+
+- Add support for unmanaged peers with `wireguard_extra_peer_config` (contribution by @joneskoo)
+
 **7.0.0**
 
 - Switched to install from ELRepo KMOD package for CentOS (see https://www.wireguard.com/install/). This change may break installation for systems with custom kernels. The role previously supported custom kernel implicitly because it was using DKMS package (contribution by @elcomtik)
-  
+
   Role removes DKMS wireguard package, however it doesn't remove jdoss-wireguard-epel-7 repository. If you don't need this repository, do cleanup by:
     * remove `/etc/yum.repos.d/wireguard.repo`
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ wireguard_save_config: "true"
 wireguard_unmanaged_peers:
   client.example.com:
     public_key: 5zsSBeZZ8P9pQaaJvY9RbELQulcwC5VBXaZ93egzOlI=
-    preshared_key: mfKkizs9J4eRFnyhaRvUKdFAxoGdDfcgMy4OhrbyjPE=
+    # preshared_key: ... e.g. from ansible-vault?
     allowed_ips: 10.0.0.3/32
     endpoint: client.example.com:51820
     persistent_keepalive: 0

--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ wireguard_postup:
 wireguard_postdown:
   - ...
 wireguard_save_config: "true"
-wireguard_extra_peer_config: |
-  # Configure external peers - not managed by ansible-role-wireguard.
-  [Peer]
-  PublicKey = 5zsSBeZZ8P9pQaaJvY9RbELQulcwC5VBXaZ93egzOlI=
-  AllowedIPs = 10.0.0.3/32
+wireguard_unmanaged_peers:
+  client.example.com:
+    public_key: 5zsSBeZZ8P9pQaaJvY9RbELQulcwC5VBXaZ93egzOlI=
+    preshared_key: mfKkizs9J4eRFnyhaRvUKdFAxoGdDfcgMy4OhrbyjPE=
+    allowed_ips: 10.0.0.3/32
+    endpoint: client.example.com:51820
+    persistent_keepalive: 0
 ```
 
 `wireguard_(preup|predown|postup|postdown)` are specified as lists. Here are two examples:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ wireguard_postup:
 wireguard_postdown:
   - ...
 wireguard_save_config: "true"
+wireguard_extra_peer_config: |
+  # Configure external peers - not managed by ansible-role-wireguard.
+  [Peer]
+  PublicKey = 5zsSBeZZ8P9pQaaJvY9RbELQulcwC5VBXaZ93egzOlI=
+  AllowedIPs = 10.0.0.3/32
 ```
 
 `wireguard_(preup|predown|postup|postdown)` are specified as lists. Here are two examples:

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -73,21 +73,21 @@ SaveConfig = true
     # Peers not managed by ansible from wireguard_unmanaged_peers
     {% for peer in wireguard_unmanaged_peers.keys() %}
     [Peer]
-    # {{ peer}}
+    # {{ peer }}
     {% if wireguard_unmanaged_peers[peer].public_key is defined %}
-    PublicKey = {{wireguard_unmanaged_peers[peer].public_key}}
+    PublicKey = {{ wireguard_unmanaged_peers[peer].public_key }}
     {% endif %}
     {% if wireguard_unmanaged_peers[peer].preshared_key is defined %}
-    PresharedKey = {{wireguard_unmanaged_peers[peer].preshared_key}}
+    PresharedKey = {{ wireguard_unmanaged_peers[peer].preshared_key }}
     {% endif %}
     {% if wireguard_unmanaged_peers[peer].allowed_ips is defined %}
-    AllowedIPs = {{wireguard_unmanaged_peers[peer].allowed_ips}}
+    AllowedIPs = {{ wireguard_unmanaged_peers[peer].allowed_ips }}
     {% endif %}
     {% if wireguard_unmanaged_peers[peer].endpoint is defined %}
-    Endpoint = {{wireguard_unmanaged_peers[peer].endpoint}}
+    Endpoint = {{ wireguard_unmanaged_peers[peer].endpoint }}
     {% endif %}
     {% if wireguard_unmanaged_peers[peer].persistent_keepalive is defined %}
-    PersistentKeepalive = {{wireguard_unmanaged_peers[peer].persistent_keepalive}}
+    PersistentKeepalive = {{ wireguard_unmanaged_peers[peer].persistent_keepalive }}
     {% endif %}
     {% endfor %}
 {% endif %}

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -41,7 +41,7 @@ SaveConfig = true
 {% endif %}
 {% for host in ansible_play_hosts %}
   {% if host != inventory_hostname %}
-  
+
     [Peer]
     # {{ host }}
     PublicKey = {{hostvars[host].public_key}}
@@ -68,3 +68,7 @@ SaveConfig = true
     {% endif %}
   {% endif %}
 {% endfor %}
+{% if wireguard_extra_peer_config is defined %}
+    # Unmanaged peers from wireguard_extra_peer_config
+    {{wireguard_extra_peer_config|indent(4, False)}}
+{% endif %}

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -74,9 +74,7 @@ SaveConfig = true
     {% for peer in wireguard_unmanaged_peers.keys() %}
     [Peer]
     # {{ peer }}
-    {% if wireguard_unmanaged_peers[peer].public_key is defined %}
     PublicKey = {{ wireguard_unmanaged_peers[peer].public_key }}
-    {% endif %}
     {% if wireguard_unmanaged_peers[peer].preshared_key is defined %}
     PresharedKey = {{ wireguard_unmanaged_peers[peer].preshared_key }}
     {% endif %}

--- a/templates/wg.conf.j2
+++ b/templates/wg.conf.j2
@@ -68,7 +68,26 @@ SaveConfig = true
     {% endif %}
   {% endif %}
 {% endfor %}
-{% if wireguard_extra_peer_config is defined %}
-    # Unmanaged peers from wireguard_extra_peer_config
-    {{wireguard_extra_peer_config|indent(4, False)}}
+{% if wireguard_unmanaged_peers is defined %}
+
+    # Peers not managed by ansible from wireguard_unmanaged_peers
+    {% for peer in wireguard_unmanaged_peers.keys() %}
+    [Peer]
+    # {{ peer}}
+    {% if wireguard_unmanaged_peers[peer].public_key is defined %}
+    PublicKey = {{wireguard_unmanaged_peers[peer].public_key}}
+    {% endif %}
+    {% if wireguard_unmanaged_peers[peer].preshared_key is defined %}
+    PresharedKey = {{wireguard_unmanaged_peers[peer].preshared_key}}
+    {% endif %}
+    {% if wireguard_unmanaged_peers[peer].allowed_ips is defined %}
+    AllowedIPs = {{wireguard_unmanaged_peers[peer].allowed_ips}}
+    {% endif %}
+    {% if wireguard_unmanaged_peers[peer].endpoint is defined %}
+    Endpoint = {{wireguard_unmanaged_peers[peer].endpoint}}
+    {% endif %}
+    {% if wireguard_unmanaged_peers[peer].persistent_keepalive is defined %}
+    PersistentKeepalive = {{wireguard_unmanaged_peers[peer].persistent_keepalive}}
+    {% endif %}
+    {% endfor %}
 {% endif %}


### PR DESCRIPTION
In order to support peers that are not managed in Ansible, add support to add peers not managed by ansible to WireGuard config. This allows easily defining peers without endpoint that can talk to all nodes being deployed. Especially useful for workstations without an endpoint address.

Add variable wireguard_unmanaged_peers that appends the peers into config.

This closes #41, and closes #45.

Example of how to use this:

```yaml
vpn:
  hosts:
    server1:
      ...
    server2:
      ...
      wireguard_unmanaged_peers:
        client.example.com:
          public_key: 5zsSBeZZ8P9pQaaJvY9RbELQulcwC5VBXaZ93egzOlI=
          allowed_ips: 10.0.0.3/32
  vars:
    wireguard_unmanaged_peers:
      client.example.com:
        public_key: 5zsSBeZZ8P9pQaaJvY9RbELQulcwC5VBXaZ93egzOlI=
        allowed_ips: 10.0.0.3/32
```