### PR TITLE
fix: create symlink for config to /etc/wireguard

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@
 # Directory to store WireGuard configuration on the remote hosts
 wireguard_remote_directory: "/etc/wireguard"
 
+# Do not change this variable. It is used as is in tasks for comparison.
+default_wireguard_remote_directory: "/etc/wireguard"
+
 # The default port WireGuard will listen if not specified otherwise.
 wireguard_port: "51820"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,6 @@
 
 # Directory to store WireGuard configuration on the remote hosts
 wireguard_remote_directory: "/etc/wireguard"
-
-# Do not change this variable. It is used as is in tasks for comparison.
 default_wireguard_remote_directory: "/etc/wireguard"
 
 # The default port WireGuard will listen if not specified otherwise.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
   tags:
     - wg-config
   notify:
-    - reconfigure wireguard
+    - "reconfigure wireguard"
 
 - name: Create config symlink to default directory
   file:
@@ -123,7 +123,7 @@
   when: default_wireguard_remote_directory != wireguard_remote_directory
   tags:
     - wg-config
-    
+
 - name: Check if reload-module-on-update is set
   stat:
     path: "{{ wireguard_remote_directory }}/.reload-module-on-update"
@@ -139,8 +139,27 @@
   tags:
     - wg-config
 
+- name: generate hosts file
+  template: src=hosts.j2 dest=/tmp/wireguard-hosts
+  run_once: true
+  delegate_to: localhost
+
+- name: add mappings to /etc/hosts
+  blockinfile:
+    path: /etc/hosts
+    block: "{{ lookup('file', '/tmp/wireguard-hosts') }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR WIREGUARD"
+
 - name: Start and enable WireGuard service
   service:
     name: "wg-quick@{{ wireguard_interface }}"
-    state: started
-    enabled: yes
+    state: restarted
+    enabled: no
+
+- name: remove temporary files
+  ignore_errors: yes
+  file:
+    state: absent
+    path: "/tmp/wireguard-hosts"
+  run_once: true
+  delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,6 +115,15 @@
   notify:
     - reconfigure wireguard
 
+- name: Create config symlink to default directory
+  file:
+    src: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
+    dest: "{{ default_wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
+    state: link
+  when: default_wireguard_remote_directory != wireguard_remote_directory
+  tags:
+    - wg-config
+    
 - name: Check if reload-module-on-update is set
   stat:
     path: "{{ wireguard_remote_directory }}/.reload-module-on-update"

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,0 +1,4 @@
+#jinja2: lstrip_blocks:"True",trim_blocks:"True"
+{% for host in ansible_play_hosts %}
+{{hostvars[host].wireguard_ip}} wg-{{hostvars[host].ansible_hostname}}
+{% endfor %}


### PR DESCRIPTION
A quick and dirty fix for wg-quick. 

Wg-quick searches for configs in `/etc/wireguard` and it cannot be changed, AFAIK. So, if for some host/group one changes `wireguard_remote_directory` variable, it will create a symlink of config to default location.