### PR TITLE
Add wireguard_private_key variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 Changelog
 ---------
 
+**7.6.0**
+- Add `wireguard_private_key` variable (contribution by @j8r)
+- Fix check mode for Debian (contribution by @j8r)
+
 **7.5.0**
 
 - `wireguard` package is now available for Ubuntu 18.04 in universe repository. Before that `ppa:wireguard/wireguard` was used but that one isn't available anymore. The install procedure for Ubuntu 18.04 and 20.04 is now the same as both can use `wireguard` metapackage now. The role takes care to remove `wireguard-dkms` package in favour of `wireguard` metapackage but it leaves the configuration file for `ppa:wireguard/wireguard` repository untouched. So it's up to you to remove that PPA. Either use `apt-add-repository --remove ppa:wireguard/wireguard` or remove the file manually at `/etc/apt/sources.list.d/` directory (you man need to run `apt-get update` afterwards).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,7 @@ wireguard_ubuntu_update_cache: "true"
 
 # Set package cache valid time
 wireguard_ubuntu_cache_valid_time: "3600"
+
+# This is sensitive: encrypt it with a tool like Ansible Vault.
+# If not set, a new one is generated on a blank configuration.
+# wireguard_private_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,10 +60,12 @@
 
   - name: Set private key fact
     set_fact:
-      wireguard__fact_private_key: "{{ wireguard__register_private_key.stdout }}"
+      wireguard_private_key: "{{ wireguard__register_private_key.stdout }}"
     tags:
       - wg-generate-keys
-  when: not wireguard__register_config_file.stat.exists
+  when:
+    - not wireguard__register_config_file.stat.exists
+    - wireguard_private_key is not defined
 
 - block:
   - name: Read WireGuard config file
@@ -75,15 +77,17 @@
 
   - name: Set private key fact
     set_fact:
-      wireguard__fact_private_key: "{{ wireguard__register_config['content'] | b64decode | regex_findall('PrivateKey = (.*)') | first }}"
+      wireguard_private_key: "{{ wireguard__register_config['content'] | b64decode | regex_findall('PrivateKey = (.*)') | first }}"
     tags:
       - wg-config
-  when: wireguard__register_config_file.stat.exists
+  when:
+    - wireguard__register_config_file.stat.exists
+    - wireguard_private_key is not defined
 
 - name: Derive WireGuard public key
   command: "wg pubkey"
   args:
-    stdin: "{{ wireguard__fact_private_key }}"
+    stdin: "{{ wireguard_private_key }}"
   register: wireguard__register_public_key
   changed_when: false
   check_mode: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,24 +27,25 @@
     - wg-install
   when: not ansible_os_family == 'Darwin'
 
-# Key handling [[[1
-- name: Register if config/private key already exists on target host
-  stat:
-    path: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
-  register: wireguard__register_config_file
+- block:
+  # Key handling [[[1
+  - name: Register if config/private key already exists on target host
+    stat:
+      path: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
+    register: wireguard__register_config_file
+
+  - name: Get wg subcommands
+    command: "wg --help"
+    register: wireguard__register_subcommands
+    changed_when: false
+    check_mode: no
+
+  - name: Check if wg syncconf subcommand is available
+    set_fact:
+      wg_syncconf: "{{ 'syncconf:' in wireguard__register_subcommands.stdout }}"
   tags:
     - wg-generate-keys
     - wg-config
-
-- name: Get wg subcommands
-  command: "wg --help"
-  register: wireguard__register_subcommands
-  changed_when: false
-  check_mode: no
-
-- name: Check if wg syncconf subcommand is available
-  set_fact:
-    wg_syncconf: "{{ 'syncconf:' in wireguard__register_subcommands.stdout }}"
 
 - name: Show syncconf subcommand status
   debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
   command: "wg --help"
   register: wireguard__register_subcommands
   changed_when: false
+  check_mode: no
 
 - name: Check if wg syncconf subcommand is available
   set_fact:
@@ -85,6 +86,7 @@
     stdin: "{{ wireguard__fact_private_key }}"
   register: wireguard__register_public_key
   changed_when: false
+  check_mode: no
   tags:
     - wg-config
 

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -20,7 +20,8 @@
 - name: (Debian) Get architecture
   command: "dpkg --print-architecture"
   register: wireguard__fact_dpkg_arch
-  changed_when: False
+  changed_when: false
+  check_mode: no
 
 - name: (Debian) Install kernel headers metapackage to ensure headers will be installed
   apt:

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -7,7 +7,7 @@
 [Interface]
 # {{ inventory_hostname }}
 Address = {{ wireguard_address }}
-PrivateKey = {{ wireguard__fact_private_key }}
+PrivateKey = {{ wireguard_private_key }}
 ListenPort = {{ wireguard_port }}
 {% if wireguard_dns is defined %}
 DNS = {{ wireguard_dns }}


### PR DESCRIPTION
Closes #65.

Setting the private key of the WireGuard VPN server allows to keep all the client configurations.
I didn't put the variable in `README.md` because it may be not recommended for everyone, and requires to encrypt the key in some way, but now it is possible to set it.

When testing my changes, I noticed the check mode was broken. It is now fixed in a commit.

I also changed a shell task to command, the later being recommended over shell. 