### PR TITLE
fix typo in syncconf handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
       set -o errexit
       set -o pipefail
       set -o nounset
-      systemctl is-active wg-quick@wg-quick@{{ wireguard_interface|quote }} || systemctl start wg-quick@{{ wireguard_interface|quote }}
+      systemctl is-active wg-quick@{{ wireguard_interface|quote }} || systemctl start wg-quick@{{ wireguard_interface|quote }}
       wg syncconf {{ wireguard_interface|quote }} <(wg-quick strip /etc/wireguard/{{ wireguard_interface|quote }}.conf)
       exit 0
   args:


### PR DESCRIPTION
https://github.com/githubixx/ansible-role-wireguard/blob/ee456757edfe77fc5004567b0e70ee88bcde612c/handlers/main.yml#L17

          systemctl is-active wg-quick@wg-quick@{{ wireguard_interface|quote }} || systemctl start wg-quick@{{ wireguard_interface|quote }}

I was just reading through this and saw what looks like an editing bug.


Anyway, the whole check `systemctl is-active wg-quick@wg-quick@{{ wireguard_interface|quote }} ||` because `systemctl start` already returns 0 for a system already started.