### PR TITLE
Raspberry Pi: Use Backports instead of Debian Unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 Changelog
 ---------
 
+**7.7.0**
+- Use wireguard packages from Debian Backports instead of Debian Sid, these packages are more suitable for a stable distribution and have less impact on the system. Packages from unstable must be removed manually (including kernel) to make the switch on an existing system. Upgrading the role has no effect other than adding Debian Backports to the Apt repositories.
+- Fix reboot mechanism in Raspbian role, now also works without `molly-guard`
+
 **7.6.0**
 - Add `wireguard_private_key` variable (contribution by @j8r)
 - Fix check mode for Debian (contribution by @j8r)

--- a/tasks/setup-debian-raspbian.yml
+++ b/tasks/setup-debian-raspbian.yml
@@ -38,7 +38,7 @@
 
 - name: (Raspbian) Reboot after kernel update (Ansible >= 2.8)
   reboot:
-    search_paths: ['/lib/molly-guard', '/usr/sbin']
+    search_paths: ['/lib/molly-guard', '/usr/sbin', '/sbin']
   when:
     - ansible_version.full is version('2.8.0', '>=')
     - wireguard__register_kernel_update is changed

--- a/tasks/setup-debian-raspbian.yml
+++ b/tasks/setup-debian-raspbian.yml
@@ -7,18 +7,21 @@
     name: gnupg
     state: present
 
-- name: (Raspbian) Add Debian repository key
+- name: (Raspbian) Add Debian repository keys
   apt_key:
     keyserver: "keyserver.ubuntu.com"
-    id: "04EE7237B7D453EC"
+    id: "{{ item }}"
     state: present
   when: ansible_lsb.id == "Raspbian"
+  with_items:
+    - "04EE7237B7D453EC"
+    - "648ACFD622F3D138"
   tags:
     - wg-install
 
-- name: (Raspbian) Add Debian Unstable repository for WireGuard
+- name: (Raspbian) Add Debian Buster Backports repository for WireGuard
   apt_repository:
-    repo: "deb http://deb.debian.org/debian unstable main"
+    repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
     update_cache: yes
   tags:


### PR DESCRIPTION
Use Debian backports instead of unstable to get wireguard. This is a more stable solution and has less impact on the system.

Unfortunately a reboot is still required.