### PR TITLE
Fix Fedora >= 33 support

### DIFF
--- a/tasks/setup-fedora-32.yml
+++ b/tasks/setup-fedora-32.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (C) 2020 Ties de Kock
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: (Fedora) Add WireGuard COPR
+  yum_repository:
+    name: "jdoss-wireguard"
+    description: "Copr repo for WireGuard owned by jdoss"
+    baseurl: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/fedora-$releasever-$basearch/"
+    gpgkey: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/pubkey.gpg"
+    gpgcheck: yes
+
+- name: (Fedora) Install WireGuard packages
+  yum:
+    name:
+      - "wireguard-dkms"
+      - "wireguard-tools"
+    state: present
+  tags:
+    - wg-install

--- a/tasks/setup-fedora.yml
+++ b/tasks/setup-fedora.yml
@@ -2,18 +2,9 @@
 # Copyright (C) 2020 Ties de Kock
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: (Fedora) Add WireGuard COPR
-  yum_repository:
-    name: "jdoss-wireguard"
-    description: "Copr repo for WireGuard owned by jdoss"
-    baseurl: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/fedora-$releasever-$basearch/"
-    gpgkey: "https://copr-be.cloud.fedoraproject.org/results/jdoss/wireguard/pubkey.gpg"
-    gpgcheck: yes
-
 - name: (Fedora) Install WireGuard packages
   yum:
     name:
-      - "wireguard-dkms"
       - "wireguard-tools"
     state: present
   tags:


### PR DESCRIPTION
This commit fixes Fedora >= 33 support.

Fedora 32 still installs the copr repo and the dkms module through 
setup-fedora-32.yml I assume that is still necessary for Fedora 32, 
though I have no box to test it with.

If the user is on Fedora 33 or higher, the default setup-fedora.yml is
used, which no longer installs the copr repo, nor the dkms module since
neither are necessary anymore: the wireguard module has been merged
in the upstream kernel and wireguard-tools is in the base OS.