### PR TITLE
Add flag to allow disabling deb repo management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,13 @@ wireguard_conf_group: "{{ 'root' if not ansible_os_family == 'Darwin' else 'whee
 wireguard_conf_mode: 0600
 
 
+######################################
+# Settings only relevant for Debian
+######################################
+
+# Set to "false" if apt repos are managed outside this role
+wireguard_debian_manage_deb_repo: "true"
+
 #######################################
 # Settings only relevant for Ubuntu
 #######################################

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -10,12 +10,14 @@
     update_cache: yes
   tags:
     - wg-install
+  when: wireguard_debian_manage_deb_repo == "true"
 
 - name: (Debian) Install kernel headers for the currently running kernel to compile Wireguard with DKMS
   apt:
     name:
       - "linux-headers-{{ ansible_kernel }}"
     state: present
+  when: wireguard_debian_manage_deb_repo == "true"
 
 - name: (Debian) Get architecture
   command: "dpkg --print-architecture"
@@ -28,7 +30,9 @@
     name:
       - "linux-headers-{{ wireguard__fact_dpkg_arch.stdout }}"
     state: present
-  when: ('-cloud-' not in ansible_kernel)
+  when:
+    - ('-cloud-' not in ansible_kernel)
+    - wireguard_debian_manage_deb_repo == "true"
 
 - name: (Debian) Install WireGuard packages
   apt:


### PR DESCRIPTION
I manage my deb repos outside of this role, so this change allows this role to work with existing repos.

Also the wireguard package is all that is needed on my debian systems, so when using existing repos it also stops installing the kernel headers/dkms stuff. Let me know if this should be separated out into a separate pull request.