### PR TITLE
Allow disabling service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,9 @@ wireguard_conf_group: "{{ 'root' if not ansible_os_family == 'Darwin' else 'whee
 # The default mode of the wg.conf file
 wireguard_conf_mode: 0600
 
+# The default state of the wireguard service
+wireguard_service_enabled: "yes"
+wireguard_service_state: "started"
 
 #######################################
 # Settings only relevant for Ubuntu

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,9 +9,10 @@
   loop:
   - stopped
   - started
-  when: >
-    not wg_syncconf and
-    not ansible_os_family == 'Darwin'
+  when:
+    - not wg_syncconf
+    - not ansible_os_family == 'Darwin'
+    - wireguard_service_enabled == "yes"
   listen: "reconfigure wireguard"
 
 - name: syncconf wireguard
@@ -24,7 +25,8 @@
       exit 0
   args:
     executable: "/bin/bash"
-  when: >
-    wg_syncconf and
-    not ansible_os_family == 'Darwin'
+  when:
+    - wg_syncconf
+    - not ansible_os_family == 'Darwin'
+    - wireguard_service_enabled == "yes"
   listen: "reconfigure wireguard"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,6 +133,6 @@
 - name: Start and enable WireGuard service
   service:
     name: "wg-quick@{{ wireguard_interface }}"
-    state: started
-    enabled: yes
+    state: "{{ wireguard_service_state }}"
+    enabled: "{{ wireguard_service_enabled }}"
   when: not ansible_os_family == 'Darwin'


### PR DESCRIPTION
On my desktop machine, I manually start/stop the wireguard service using wg-quick. This change allows disabling the service to allow wg-quick to do its thing.