### PR TITLE
Fix tag "wg-install" & Add no_log

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,13 +6,19 @@
   setup:
 
 # Installing WireGuard [[[1
-- include_tasks: "{{ item }}"
+- include_tasks:
+    file: "{{ item }}"
+    apply:
+      tags:
+        - wg-install
   with_first_found:
     - "setup-{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml"
     - "setup-{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml"
     - "setup-{{ ansible_distribution|lower }}-{{ ansible_distribution_release }}.yml"
     - "setup-{{ ansible_distribution|lower }}.yml"
     - "setup-{{ ansible_os_family|lower }}.yml"
+  tags:
+    - wg-install
 
 - name: Enable WireGuard kernel module
   modprobe:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,12 +62,14 @@
     command: "wg genkey"
     register: wireguard__register_private_key
     changed_when: false
+    no_log: '{{ ansible_verbosity < 3 }}'
     tags:
       - wg-generate-keys
 
   - name: Set private key fact
     set_fact:
       wireguard_private_key: "{{ wireguard__register_private_key.stdout }}"
+    no_log: '{{ ansible_verbosity < 3 }}'
     tags:
       - wg-generate-keys
   when:
@@ -79,12 +81,14 @@
     slurp:
       src: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
     register: wireguard__register_config
+    no_log: '{{ ansible_verbosity < 3 }}'
     tags:
       - wg-config
 
   - name: Set private key fact
     set_fact:
       wireguard_private_key: "{{ wireguard__register_config['content'] | b64decode | regex_findall('PrivateKey = (.*)') | first }}"
+    no_log: '{{ ansible_verbosity < 3 }}'
     tags:
       - wg-config
   when:
@@ -98,6 +102,7 @@
   register: wireguard__register_public_key
   changed_when: false
   check_mode: no
+  no_log: '{{ ansible_verbosity < 3 }}'
   tags:
     - wg-config
 
@@ -123,6 +128,7 @@
     owner: "{{ wireguard_conf_owner }}"
     group: "{{ wireguard_conf_group }}"
     mode: "{{ wireguard_conf_mode }}"
+  no_log: '{{ ansible_verbosity < 3 }}'
   tags:
     - wg-config
   notify:

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -10,8 +10,6 @@
     - { name: wireguard-dkms, state: absent }
     - { name: wireguard-lts, state: present }
   become: yes
-  tags:
-    - wg-install
   when:
     - ansible_kernel is match(".*-lts$")
     - ansible_kernel is version('5.6', '<')
@@ -21,8 +19,6 @@
     name: wireguard-dkms
     state: present
   become: yes
-  tags:
-    - wg-install
   when:
     - not ansible_kernel is match(".*-lts$")
     - ansible_kernel is version('5.6', '<')
@@ -31,5 +27,3 @@
   pacman:
     name: wireguard-tools
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-centos-7.yml
+++ b/tasks/setup-centos-7.yml
@@ -19,8 +19,6 @@
     name:
       - "wireguard-dkms"
     state: absent
-  tags:
-    - wg-install
 
 - name: (CentOS 7) Install WireGuard packages
   yum:
@@ -28,5 +26,3 @@
       - "kmod-wireguard"
       - "wireguard-tools"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-centos-8.yml
+++ b/tasks/setup-centos-8.yml
@@ -14,8 +14,6 @@
     name:
       - "wireguard-dkms"
     state: absent
-  tags:
-    - wg-install
 
 - name: (CentOS 8) Install WireGuard packages
   yum:
@@ -23,5 +21,3 @@
       - "kmod-wireguard"
       - "wireguard-tools"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-debian-pve-variant.yml
+++ b/tasks/setup-debian-pve-variant.yml
@@ -9,8 +9,6 @@
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: "{{ 'present' if (ansible_distribution_version | int <= 10) else 'absent' }}"
     update_cache: yes
-  tags:
-    - wg-install
 
 - name: (Proxmox) Install kernel headers for the currently running kernel to compile WireGuard with DKMS
   apt:
@@ -23,5 +21,3 @@
     name:
       - "wireguard"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-debian-raspbian.yml
+++ b/tasks/setup-debian-raspbian.yml
@@ -16,16 +16,12 @@
   with_items:
     - "04EE7237B7D453EC"
     - "648ACFD622F3D138"
-  tags:
-    - wg-install
 
 - name: (Raspbian) Add Debian Buster Backports repository for WireGuard
   apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
     update_cache: yes
-  tags:
-    - wg-install
 
 - name: (Raspbian) Install latest kernel
   apt:
@@ -33,8 +29,6 @@
     - "raspberrypi-kernel"
     state: latest
   register: wireguard__register_kernel_update
-  tags:
-    - wg-install
 
 - name: (Raspbian) Reboot after kernel update (Ansible >= 2.8)
   reboot:
@@ -42,8 +36,6 @@
   when:
     - ansible_version.full is version('2.8.0', '>=')
     - wireguard__register_kernel_update is changed
-  tags:
-    - wg-install
 
 - name: (Raspbian) Check if molly-guard is installed (Ansible < 2.8)
   stat:
@@ -56,8 +48,6 @@
     - ansible_version.full is version('2.8.0', '<')
     - wireguard__register_kernel_update is changed
     - not wireguard__register_molly_guard.stat.exists
-  tags:
-    - wg-install
 
 - name: (Raspbian) Reboot after kernel update (Ansible < 2.8, with molly-guard)
   command: /lib/molly-guard/shutdown -r now
@@ -68,8 +58,6 @@
     - ansible_version.full is version('2.8.0', '<')
     - wireguard__register_kernel_update is changed
     - wireguard__register_molly_guard.stat.exists
-  tags:
-    - wg-install
 
 - name: (Raspbian) Waiting for host to be available (Ansible < 2.8, with molly-guard)
   wait_for_connection:
@@ -77,16 +65,12 @@
     - ansible_version.full is version('2.8.0', '<')
     - wireguard__register_kernel_update is changed
     - wireguard__register_molly_guard.stat.exists
-  tags:
-    - wg-install
 
 - name: (Raspbian) Install latest kernel headers to compile Wireguard with DKMS
   apt:
     name:
     - "raspberrypi-kernel-headers"
     state: latest
-  tags:
-    - wg-install
 
 - name: (Raspbian) Install WireGuard packages
   apt:
@@ -94,5 +78,3 @@
       - "wireguard-dkms"
       - "wireguard-tools"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -8,8 +8,6 @@
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: "{{ 'present' if (ansible_distribution_version | int <= 10) else 'absent' }}"
     update_cache: yes
-  tags:
-    - wg-install
 
 - name: (Debian) Install kernel headers for the currently running kernel to compile Wireguard with DKMS
   apt:
@@ -35,5 +33,3 @@
     name:
       - "wireguard"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -3,15 +3,27 @@
 # Copyright (C) 2021 Steve Fan
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include_tasks: "setup-debian-raspbian.yml"
+- include_tasks:
+    file: "setup-debian-raspbian.yml"
+    apply:
+      tags:
+        - wg-install
   when: ansible_lsb.id is defined and ansible_lsb.id == "Raspbian"
   register: wireguard__register_raspbian_setup
 
-- include_tasks: "setup-debian-pve-variant.yml"
+- include_tasks:
+    file: "setup-debian-pve-variant.yml"
+    apply:
+      tags:
+        - wg-install
   when: ansible_kernel.find("pve") != -1
   register: wireguard__register_pve_variant_setup
 
-- include_tasks: "setup-debian-vanilla.yml"
+- include_tasks:
+    file: "setup-debian-vanilla.yml"
+    apply:
+      tags:
+        - wg-install
   when:
     - wireguard__register_raspbian_setup is skipped
     - wireguard__register_pve_variant_setup is skipped

--- a/tasks/setup-fedora-32.yml
+++ b/tasks/setup-fedora-32.yml
@@ -16,5 +16,3 @@
       - "wireguard-dkms"
       - "wireguard-tools"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-fedora.yml
+++ b/tasks/setup-fedora.yml
@@ -7,5 +7,3 @@
     name:
       - "wireguard-tools"
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-macosx.yml
+++ b/tasks/setup-macosx.yml
@@ -7,12 +7,8 @@
     name: wireguard-go
     state: present
   become: yes
-  tags:
-    - wg-install
 
 - name: (MacOS) Install wireguard-tools package
   package:
     name: wireguard-tools
     state: present
-  tags:
-    - wg-install

--- a/tasks/setup-opensuse leap.yml
+++ b/tasks/setup-opensuse leap.yml
@@ -8,6 +8,3 @@
     name:
       - "wireguard-tools"
     state: present
-  tags:
-    - wg-install
-

--- a/tasks/setup-ubuntu.yml
+++ b/tasks/setup-ubuntu.yml
@@ -6,8 +6,6 @@
   apt:
     update_cache: "{{ wireguard_ubuntu_update_cache }}"
     cache_valid_time: "{{ wireguard_ubuntu_cache_valid_time }}"
-  tags:
-    - wg-install
 
 - block:
   - name: (Ubuntu) Install support packages needed for Wireguard (for Ubuntu < 19.10)
@@ -18,8 +16,6 @@
       packages:
       - software-properties-common
       - linux-headers-{{ ansible_kernel }}
-    tags:
-      - wg-install
   when:
     - ansible_lsb.major_release is version('19.10', '<')
 
@@ -28,12 +24,8 @@
     name:
       - "wireguard-dkms"
     state: absent
-  tags:
-    - wg-install
 
 - name: (Ubuntu) Install wireguard package
   apt:
     name: "wireguard"
     state: present
-  tags:
-    - wg-install


### PR DESCRIPTION
This PR fixes #109 & #81 

Background to the change on the tag:
Tags are evaluated at the start of a play, so any include, that is evaluated at runtime, will not result in having any tag-functionality applied to included tasks/roles, unless tags are applied via the parameter "apply".
https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#tag-inheritance-for-includes-blocks-and-the-apply-keyword
By adding "tags" to the main.yml-include_tasks-Task, this task is respected, if "wg-install" is given via "skip-tags" or "tags".
By adding "apply"-"tags", the defined tag "wg-install" ist applied to all included tasks and all included tasks are handled, when given the tag "wg-install" via "tags"-option.

As for no_log:
Default verbosity of 0 or slight increases up to 2 will now not print any private keys to output.
If anyone desires to see the output of these tasks, the verbosity can be increased to 3 or more to disable no_log.