### PR TITLE
* New: Set managed peer optional to install single server or multiserver on mesh mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@
 # General settings
 #######################################
 
+wireguard_managed_peers_enabled: True
+
 # Directory to store WireGuard configuration on the remote hosts
 wireguard_remote_directory: "{{ '/etc/wireguard' if not ansible_os_family == 'Darwin' else '/opt/local/etc/wireguard' }}"
 

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -44,6 +44,7 @@ PostDown = {{ wg_postdown }}
 {% if wireguard_save_config is defined %}
 SaveConfig = true
 {% endif %}
+{% if wireguard_managed_peers_enabled %}
 {% for host in ansible_play_hosts %}
 {%   if host != inventory_hostname %}
 
@@ -82,6 +83,7 @@ Endpoint = {{host}}:{{wireguard_port}}
 {%     endif %}
 {%   endif %}
 {% endfor %}
+{% endif %}
 {% if wireguard_unmanaged_peers is defined %}
 
 # Peers not managed by Ansible from "wireguard_unmanaged_peers" variable


### PR DESCRIPTION
Hi about my issue: #120 we can found a solution to implement in our case use.

this role by default create mesh wireguard connection witch is very useful and as plus we add a new variable condition to can install as a single server or multiple single server in the same ansible_group, 

this new variable is defined by default to work backward compatible role.

thanks for your effort.