### PR TITLE
Add support for Rocky Linux 8

### DIFF
--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -1,0 +1,1 @@
+setup-centos-8.yml


### PR DESCRIPTION
Hello, would you consider adding support for Rocky Linux 8. A simple symlink works fine : 
`setup-rocky-8.yml -> setup-centos-8.yml`

There might be a smarter way to do this with these facts : 
```
"ansible_distribution_file_variety": "RedHat"
"ansible_distribution_major_version": "8"
```
As RHEL8, CentOS 8 (soon dead), RockyLinux 8 and AlmaLinux 8 (not tested tho)  will work the same way.