### PR TITLE
feat: Update CentOS 7 to use signed kernel-plus module

### DIFF
--- a/tasks/setup-centos-7.yml
+++ b/tasks/setup-centos-7.yml
@@ -2,17 +2,24 @@
 # Copyright (C) 2020 Roman Danko
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: (CentOS 7) Install EPEL & ELRepo repository
+- name: (CentOS 7) Install EPEL repository & yum utils
   yum:
     name:
       - epel-release
-      - https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
+      - yum-utils
     update_cache: true
 
-- name: (CentOS 7) Install yum-plugin-elrepo
-  yum:
-    name: yum-plugin-elrepo
-    update_cache: true
+- name: (CentOS 7) Enable CentosPlus repo
+  command: "yum-config-manager"
+  args:
+    stdin: "--setopt=centosplus.includepkgs=kernel-plus --enablerepo=centosplus --save"
+  changed_when: false
+
+- name: (CentOS 7) Update to kernel-plus
+  ansible.builtin.replace:
+    path: /etc/sysconfig/kernel
+    regexp: '^DEFAULTKERNEL=kernel$'
+    replace: 'DEFAULTKERNEL=kernel-plus'
 
 - name: (CentOS 7) Ensure WireGuard DKMS package is removed
   yum:
@@ -23,6 +30,6 @@
 - name: (CentOS 7) Install WireGuard packages
   yum:
     name:
-      - "kmod-wireguard"
+      - "kernel-plus"
       - "wireguard-tools"
     state: present


### PR DESCRIPTION
Updated the CentOS 7 tasks to use kernel-plus and the built-in signed module for WireGuard instead of the standard kernel and ELRepo's module to better support hardening that requires signed kernel modules.