### PR TITLE
Add  to allow host specific AllowedIPs configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 Changelog
 ---------
 
+**8.5.0**
+
+- add `wireguard_allowed_ips_override` to allow host specific AllowedIPs configuration (contribution by @tobias-richter)
+
 **8.4.0**
 
 - add support for installing wireguard in pve lxc guest (contribution by @tobias-richter)

--- a/README.md
+++ b/README.md
@@ -112,10 +112,20 @@ Endpoint = controller01.p.domain.tld:51820
 
 Now this is basically the same as above BUT now the config says: I want to route EVERY traffic originating from my workstation to the endpoint `controller01.p.domain.tld:51820`. If that endpoint can handle the traffic is of course another thing and it's up to you how you configure the endpoint routing ;-)
 
+To override `wireguard_allowed_ips` for a managed peer when the config is rendered on a specific host you can use the option `wireguard_allowed_ips_override`.
+Based on the Kubernetes example below the managed peer `controller01.i.domain.tld` will get `AllowedIPs` setting of `10.8.0.101/32` on all other managed peers that are part of the play.
+In our example we want to allow an additional subnet on `controller02.i.domain.tld`. This can be done by configuring `wireguard_allowed_ips_override` in `host_vars/controller01.i.domain.tld`.
+When the config of `controller01.i.domain.tld` is rendered on `controller02.i.domain.tld` this value is used and only on `controller02.i.domain.tld` the `AllowedIPs` is set to `10.8.0.101/32, 10.7.0.0/24`.
+```yaml
+wireguard_allowed_ips_override:
+  "controller02.i.domain.tld": "10.8.0.101/32, 10.7.0.0/24"
+```
+
 You can specify further optional settings (they don't have a default and won't be set if not specified besides `wireguard_allowed_ips` as already mentioned) also per host in `host_vars/` (or in your Ansible hosts file if you like). The values for the following variables are just examples and no defaults (for more information and examples see [wg-quick.8](https://git.zx2c4.com/WireGuard/about/src/tools/man/wg-quick.8)):
 
 ```yaml
 wireguard_allowed_ips: ""
+wireguard_allowed_ips_override: {}
 wireguard_endpoint: "host1.domain.tld"
 wireguard_persistent_keepalive: "30"
 wireguard_dns: "1.1.1.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ wireguard_ubuntu_update_cache: "true"
 # Set package cache valid time
 wireguard_ubuntu_cache_valid_time: "3600"
 
+# Allows overriding of AllowedIPs on host_var base
+wireguard_allowed_ips_override: {}
+
 #######################################
 # Settings only relevant for CentOS 7
 #######################################

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -50,7 +50,9 @@ SaveConfig = true
 [Peer]
 # {{ host }}
 PublicKey = {{hostvars[host].wireguard__fact_public_key}}
-{%     if hostvars[host].wireguard_allowed_ips is defined %}
+{%     if hostvars[host].wireguard_allowed_ips_override[inventory_hostname] is defined %}
+AllowedIPs = {{hostvars[host].wireguard_allowed_ips_override[inventory_hostname]}}
+{%     elif hostvars[host].wireguard_allowed_ips is defined %}
 AllowedIPs = {{hostvars[host].wireguard_allowed_ips}}
 {%     else %}
 AllowedIPs = {{ hostvars[host].wireguard_address.split('/')[0] }}/32


### PR DESCRIPTION
At the moment it is not possible to set the `AllowedIPs` on host base.
In my setup this is required because one peer is part of two subnets.

```
       peer_a <->
                  peer_b
backup_peer_a <-> 
```
peer_a has the subnets 192.168.0.0/24
backup_peer_is connected to the subnets 192.168.0.0/24 and 192.168.1.0/24 (Backup Line)
peer_bhas the subnets 192.168.2.0/24

Assuming these are the configs:

`host_vars/peer_a.yaml`:
```yaml
wireguard_address: 10.8.0.1/24
wireguard_allowed_ips: 10.8.0.1/32, 192.168.0.0/24
```
`host_vars/backup_peer_a.yaml`:
```yaml
wireguard_address: 10.8.0.2/24
wireguard_allowed_ips: 10.8.0.2/32, 192.168.1.0/24
```

**Problem:**

`backup_peer_a ` will get a peer for `peer_a ` with `AllowedIPs=10.8.0.1/32, 192.168.0.0/24`.
Since `backup_peer_a ` is also directly connected to `192.168.0.0/24` this will lead to routing issues and the host may not be reachable from hosts within `192.168.0.0/24`.

So I introduced `wireguard_allowed_ips_override` to able to override `AllowedIPs` based on `inventory_hostname`.

In this example we would add the override in the `host_vars/peer_a.yaml`:
```yaml
wireguard_address: 10.8.0.1/24
wireguard_allowed_ips: 10.8.0.1/32, 192.168.0.0/24

wireguard_allowed_ips_override:
  "backup_peer_a": 10.8.0.1/32
```
So when the managed peer config of `peer_a` is rendered on `backup_peer_a` the value from the `wireguard_allowed_ips_override` is taken.

@githubixx i hope you could follow me so far :) Another solution to solve this problem would be to make the template path adjustable to be able to work with a custom template.