### PR TITLE
General improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 Changelog
 ---------
 
+**9.0.0**
+
+- set minimally required Ansible version to 2.9
+- fully qualify modules names (requires Ansible >= 2.9)
+- rearrange hooks to match lifecycle order
+
 **8.4.0**
 
 - add support for installing wireguard in pve lxc guest (contribution by @tobias-richter)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: restart wireguard
-  service:
+  ansible.builtin.service:
     name: "wg-quick@{{ wireguard_interface }}"
     state: "{{ item }}"
   loop:
@@ -16,7 +16,7 @@
   listen: "reconfigure wireguard"
 
 - name: syncconf wireguard
-  shell: |
+  ansible.builtin.shell: |
     set -o errexit
     set -o pipefail
     set -o nounset

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: Robert Wimmer
   description: Installs Wireguard incl. systemd integration
   license: GPL-3.0-or-later
-  min_ansible_version: 2.7
+  min_ansible_version: 2.9
   role_name: ansible_role_wireguard
   namespace: githubixx
   platforms:

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -8,7 +8,7 @@
   gather_facts: true
   tasks:
     - name: Init pacman
-      raw: |
+      ansible.builtin.raw: |
         pacman-key --init
         pacman-key --populate archlinux
       changed_when: false
@@ -16,12 +16,12 @@
       when: ansible_distribution|lower == 'archlinux'
 
     - name: (Proxmox) Delete /var/lib/apt/lists/lock
-      file:
+      ansible.builtin.file:
         name: /var/lib/apt/lists/lock
         state: absent
       ignore_errors: true
       when: ansible_kernel.find("pve") != -1
 
     - name: Include WireGuard role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.ansible_role_wireguard

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Gather instance facts
-  setup:
+  ansible.builtin.setup:
 
-- include_tasks:
+- ansible.builtin.include_tasks:
     file: "{{ item }}"
     apply:
       tags:
@@ -20,7 +20,7 @@
     - wg-install
 
 - name: Enable WireGuard kernel module
-  modprobe:
+  community.general.modprobe:
     name: wireguard
     state: present
   register: wireguard__register_module_enabled
@@ -35,22 +35,22 @@
 - name: Generate keys | Check wg syncconf subcommand status
   block:
     - name: Register if config/private key already exists on target host
-      stat:
+      ansible.builtin.stat:
         path: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
       register: wireguard__register_config_file
 
     - name: Get wg subcommands
-      command: "wg --help"
+      ansible.builtin.command: "wg --help"
       register: wireguard__register_subcommands
       changed_when: false
       check_mode: false
 
     - name: Check if wg syncconf subcommand is available
-      set_fact:
+      ansible.builtin.set_fact:
         wg_syncconf: "{{ 'syncconf:' in wireguard__register_subcommands.stdout }}"
 
     - name: Show syncconf subcommand status
-      debug:
+      ansible.builtin.debug:
         var: wg_syncconf
   tags:
     - wg-generate-keys
@@ -59,7 +59,7 @@
 - name: WireGuard private key handling for new keys
   block:
     - name: Generate WireGuard private key
-      command: "wg genkey"
+      ansible.builtin.command: "wg genkey"
       register: wireguard__register_private_key
       changed_when: false
       no_log: '{{ ansible_verbosity < 3 }}'
@@ -67,7 +67,7 @@
         - wg-generate-keys
 
     - name: Set private key fact
-      set_fact:
+      ansible.builtin.set_fact:
         wireguard_private_key: "{{ wireguard__register_private_key.stdout }}"
       no_log: '{{ ansible_verbosity < 3 }}'
       tags:
@@ -79,7 +79,7 @@
 - name: WireGuard private key handling for existing keys
   block:
     - name: Read WireGuard config file
-      slurp:
+      ansible.builtin.slurp:
         src: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
       register: wireguard__register_config
       no_log: '{{ ansible_verbosity < 3 }}'
@@ -87,7 +87,7 @@
         - wg-config
 
     - name: Set private key fact
-      set_fact:
+      ansible.builtin.set_fact:
         wireguard_private_key: "{{ wireguard__register_config['content'] | b64decode | regex_findall('PrivateKey = (.*)') | first }}"
       no_log: '{{ ansible_verbosity < 3 }}'
       tags:
@@ -97,7 +97,7 @@
     - wireguard_private_key is not defined
 
 - name: Derive WireGuard public key
-  command: "wg pubkey"
+  ansible.builtin.command: "wg pubkey"
   args:
     stdin: "{{ wireguard_private_key }}"
   register: wireguard__register_public_key
@@ -108,13 +108,13 @@
     - wg-config
 
 - name: Set public key fact
-  set_fact:
+  ansible.builtin.set_fact:
     wireguard__fact_public_key: "{{ wireguard__register_public_key.stdout }}"
   tags:
     - wg-config
 
 - name: Create WireGuard configuration directory
-  file:
+  ansible.builtin.file:
     dest: "{{ wireguard_remote_directory }}"
     state: directory
     mode: 0700
@@ -122,7 +122,7 @@
     - wg-config
 
 - name: Generate WireGuard configuration file
-  template:
+  ansible.builtin.template:
     src: etc/wireguard/wg.conf.j2
     dest: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
     owner: "{{ wireguard_conf_owner }}"
@@ -135,14 +135,14 @@
     - reconfigure wireguard
 
 - name: Ensure legacy reload-module-on-update is absent
-  file:
+  ansible.builtin.file:
     dest: "{{ wireguard_remote_directory }}/.reload-module-on-update"
     state: absent
   tags:
     - wg-config
 
 - name: Start and enable WireGuard service
-  service:
+  ansible.builtin.service:
     name: "wg-quick@{{ wireguard_interface }}"
     state: "{{ wireguard_service_state }}"
     enabled: "{{ wireguard_service_enabled }}"

--- a/tasks/setup-almalinux-8.yml
+++ b/tasks/setup-almalinux-8.yml
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (AlmaLinux 8) Install EPEL & ELRepo repository
-  yum:
+  ansible.builtin.yum:
     name:
       - epel-release
       - elrepo-release
     update_cache: true
 
 - name: (AlmaLinux 8) Ensure WireGuard DKMS package is removed
-  yum:
+  ansible.builtin.yum:
     name:
       - "wireguard-dkms"
     state: absent
 
 - name: (AlmaLinux 8) Install WireGuard packages
-  yum:
+  ansible.builtin.yum:
     name:
       - "kmod-wireguard"
       - "wireguard-tools"

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Archlinux) Install wireguard-tools package
-  pacman:
+  ansible.builtin.pacman:
     name: wireguard-tools
     state: present

--- a/tasks/setup-centos-7.yml
+++ b/tasks/setup-centos-7.yml
@@ -5,19 +5,19 @@
 - name: (CentOS 7) Tasks for standard kernel
   block:
     - name: (CentOS 7) Install EPEL & ELRepo repository
-      yum:
+      ansible.builtin.yum:
         name:
           - epel-release
           - https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
         update_cache: true
 
     - name: (CentOS 7) Install yum-plugin-elrepo
-      yum:
+      ansible.builtin.yum:
         name: yum-plugin-elrepo
         update_cache: true
 
     - name: (CentOS 7) Install WireGuard packages
-      yum:
+      ansible.builtin.yum:
         name:
           - "kmod-wireguard"
           - "wireguard-tools"
@@ -26,7 +26,7 @@
     - wireguard_centos7_installation_method == "standard"
 
 - name: (CentOS 7) Ensure WireGuard DKMS package is removed
-  yum:
+  ansible.builtin.yum:
     name:
       - "wireguard-dkms"
     state: absent
@@ -34,24 +34,24 @@
 - name: (CentOS 7) Tasks for kernel-plus
   block:
     - name: (CentOS 7) Install EPEL repository & yum utils
-      yum:
+      ansible.builtin.yum:
         name:
           - epel-release
           - yum-utils
         update_cache: true
 
     - name: (CentOS 7) Enable CentosPlus repo
-      command: yum-config-manager --setopt=centosplus.includepkgs=kernel-plus --enablerepo=centosplus --save
+      ansible.builtin.command: yum-config-manager --setopt=centosplus.includepkgs=kernel-plus --enablerepo=centosplus --save
       changed_when: false
 
     - name: (CentOS 7) Update to kernel-plus
-      replace:
+      ansible.builtin.replace:
         path: /etc/sysconfig/kernel
         regexp: '^DEFAULTKERNEL=kernel$'
         replace: 'DEFAULTKERNEL=kernel-plus'
 
     - name: (CentOS 7) Install WireGuard packages
-      yum:
+      ansible.builtin.yum:
         name:
           - "kernel-plus"
           - "wireguard-tools"
@@ -59,7 +59,7 @@
       register: centos7_yum_updates
 
     - name: (CentOS 7) Reboot Instance to update kernel
-      reboot:
+      ansible.builtin.reboot:
         reboot_timeout: "{{ wireguard_centos7_kernel_plus_reboot_timeout }}"
       when:
         - centos7_yum_updates.changes is defined

--- a/tasks/setup-centos-8.yml
+++ b/tasks/setup-centos-8.yml
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (CentOS 8) Install EPEL & ELRepo repository
-  yum:
+  ansible.builtin.yum:
     name:
       - epel-release
       - elrepo-release
     update_cache: true
 
 - name: (CentOS 8) Ensure WireGuard DKMS package is removed
-  yum:
+  ansible.builtin.yum:
     name:
       - "wireguard-dkms"
     state: absent
 
 - name: (CentOS 8) Install WireGuard packages
-  yum:
+  ansible.builtin.yum:
     name:
       - "kmod-wireguard"
       - "wireguard-tools"

--- a/tasks/setup-debian-pve-guest-variant.yml
+++ b/tasks/setup-debian-pve-guest-variant.yml
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Proxmox) Add WireGuard repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: "{{ 'present' if (ansible_distribution_version | int <= 10) else 'absent' }}"
     update_cache: true
 
 - name: (Proxmox lxc) Install wireguard-tools.
-  apt:
+  ansible.builtin.apt:
     install_recommends: no
     name:
       - wireguard-tools

--- a/tasks/setup-debian-pve-host-variant.yml
+++ b/tasks/setup-debian-pve-host-variant.yml
@@ -5,19 +5,19 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Proxmox) Add WireGuard repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: "{{ 'present' if (ansible_distribution_version | int <= 10) else 'absent' }}"
     update_cache: true
 
 - name: (Proxmox) Install kernel headers for the currently running kernel to compile WireGuard with DKMS
-  apt:
+  ansible.builtin.apt:
     name:
       - "pve-headers-{{ ansible_kernel }}"
     state: present
 
 - name: (Proxmox) Install WireGuard packages
-  apt:
+  ansible.builtin.apt:
     name:
       - "wireguard"
     state: present

--- a/tasks/setup-debian-raspbian.yml
+++ b/tasks/setup-debian-raspbian.yml
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Raspbian) Install GPG - required to add WireGuard key
-  apt:
+  ansible.builtin.apt:
     name: gnupg
     state: present
 
 - name: (Raspbian) Add Debian repository keys
-  apt_key:
+  ansible.builtin.apt_key:
     keyserver: "keyserver.ubuntu.com"
     id: "{{ item }}"
     state: present
@@ -18,39 +18,39 @@
     - "648ACFD622F3D138"
 
 - name: (Raspbian) Add Debian Buster Backports repository for WireGuard
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
     update_cache: true
 
 - name: (Raspbian) Install latest kernel
-  apt:
+  ansible.builtin.apt:
     name:
       - "raspberrypi-kernel"
     state: latest
   register: wireguard__register_kernel_update
 
 - name: (Raspbian) Reboot after kernel update (Ansible >= 2.8)
-  reboot:
+  ansible.builtin.reboot:
     search_paths: ['/lib/molly-guard', '/usr/sbin', '/sbin']
   when:
     - ansible_version.full is version('2.8.0', '>=')
     - wireguard__register_kernel_update is changed
 
 - name: (Raspbian) Check if molly-guard is installed (Ansible < 2.8)
-  stat:
+  ansible.builtin.stat:
     path: /lib/molly-guard/
   register: wireguard__register_molly_guard
 
 - name: (Raspbian) Reboot after kernel update (Ansible < 2.8, no molly-guard)
-  reboot:
+  ansible.builtin.reboot:
   when:
     - ansible_version.full is version('2.8.0', '<')
     - wireguard__register_kernel_update is changed
     - not wireguard__register_molly_guard.stat.exists
 
 - name: (Raspbian) Reboot after kernel update (Ansible < 2.8, with molly-guard)
-  command: /lib/molly-guard/shutdown -r now
+  ansible.builtin.command: /lib/molly-guard/shutdown -r now
   async: 1
   poll: 0
   ignore_unreachable: true
@@ -60,20 +60,20 @@
     - wireguard__register_molly_guard.stat.exists
 
 - name: (Raspbian) Waiting for host to be available (Ansible < 2.8, with molly-guard)
-  wait_for_connection:
+  ansible.builtin.wait_for_connection:
   when:
     - ansible_version.full is version('2.8.0', '<')
     - wireguard__register_kernel_update is changed
     - wireguard__register_molly_guard.stat.exists
 
 - name: (Raspbian) Install latest kernel headers to compile Wireguard with DKMS
-  apt:
+  ansible.builtin.apt:
     name:
       - "raspberrypi-kernel-headers"
     state: latest
 
 - name: (Raspbian) Install WireGuard packages
-  apt:
+  ansible.builtin.apt:
     name:
       - "wireguard-dkms"
       - "wireguard-tools"

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -6,25 +6,25 @@
 - name: (Debian) Tasks for Debian version <= 10
   block:
     - name: (Debian) Add WireGuard repository on buster
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "deb http://deb.debian.org/debian buster-backports main"
         state: present
         update_cache: true
 
     - name: (Debian) Install kernel headers for the currently running kernel to compile Wireguard with DKMS
-      apt:
+      ansible.builtin.apt:
         name:
           - "linux-headers-{{ ansible_kernel }}"
         state: present
 
     - name: (Debian) Get architecture
-      command: "dpkg --print-architecture"
+      ansible.builtin.command: "dpkg --print-architecture"
       register: wireguard__fact_dpkg_arch
       changed_when: false
       check_mode: false
 
     - name: (Debian) Install kernel headers metapackage to ensure headers will be installed
-      apt:
+      ansible.builtin.apt:
         name:
           - "linux-headers-{{ wireguard__fact_dpkg_arch.stdout }}"
         state: present
@@ -34,7 +34,7 @@
     - ansible_lsb.major_release is version('11', '<')
 
 - name: (Debian) Install WireGuard packages
-  apt:
+  ansible.builtin.apt:
     name:
       - "wireguard"
     state: present

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -3,7 +3,7 @@
 # Copyright (C) 2021 Steve Fan
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include_tasks:
+- ansible.builtin.include_tasks:
     file: "setup-debian-raspbian.yml"
     apply:
       tags:
@@ -13,7 +13,7 @@
 
 - name: pve variants
   block:
-  - include_tasks:
+  - ansible.builtin.include_tasks:
       file: "setup-debian-pve-host-variant.yml"
       apply:
         tags:
@@ -22,7 +22,7 @@
       - ansible_virtualization_role == "host"
     register: wireguard__register_pve_host_variant_setup
 
-  - include_tasks:
+  - ansible.builtin.include_tasks:
       file: "setup-debian-pve-guest-variant.yml"
       apply:
         tags:
@@ -35,7 +35,7 @@
     - ansible_kernel.find("pve") != -1
 
 
-- include_tasks:
+- ansible.builtin.include_tasks:
     file: "setup-debian-vanilla.yml"
     apply:
       tags:

--- a/tasks/setup-fedora.yml
+++ b/tasks/setup-fedora.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Fedora) Install WireGuard packages
-  yum:
+  ansible.builtin.yum:
     name:
       - "wireguard-tools"
     state: present

--- a/tasks/setup-macosx.yml
+++ b/tasks/setup-macosx.yml
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (MacOS) Install wireguard package
-  package:
+  ansible.builtin.package:
     name: wireguard-go
     state: present
   become: true
 
 - name: (MacOS) Install wireguard-tools package
-  package:
+  ansible.builtin.package:
     name: wireguard-tools
     state: present

--- a/tasks/setup-opensuse leap.yml
+++ b/tasks/setup-opensuse leap.yml
@@ -4,7 +4,7 @@
 
 
 - name: (openSUSE Leap) Install WireGuard packages
-  zypper:
+  community.general.zypper:
     name:
       - "wireguard-tools"
     state: present

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Rocky Linux 8) Install EPEL & ELRepo repository
-  yum:
+  ansible.builtin.yum:
     name:
       - epel-release
       - elrepo-release
     update_cache: true
 
 - name: (Rocky Linux 8) Ensure WireGuard DKMS package is removed
-  yum:
+  ansible.builtin.yum:
     name:
       - "wireguard-dkms"
     state: absent
 
 - name: (Rocky Linux 8) Install WireGuard packages
-  yum:
+  ansible.builtin.yum:
     name:
       - "kmod-wireguard"
       - "wireguard-tools"

--- a/tasks/setup-ubuntu.yml
+++ b/tasks/setup-ubuntu.yml
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Ubuntu) Update APT package cache
-  apt:
+  ansible.builtin.apt:
     update_cache: "{{ wireguard_ubuntu_update_cache }}"
     cache_valid_time: "{{ wireguard_ubuntu_cache_valid_time }}"
 
 - name: (Ubuntu) Tasks for Ubuntu < 19.10
   block:
     - name: (Ubuntu) Install support packages needed for Wireguard (for Ubuntu < 19.10)
-      package:
+      ansible.builtin.package:
         name: "{{ packages }}"
         state: present
       vars:
@@ -21,12 +21,12 @@
     - ansible_lsb.major_release is version('19.10', '<')
 
 - name: (Ubuntu) Ensure WireGuard DKMS package is removed
-  apt:
+  ansible.builtin.apt:
     name:
       - "wireguard-dkms"
     state: absent
 
 - name: (Ubuntu) Install wireguard package
-  apt:
+  ansible.builtin.apt:
     name: "wireguard"
     state: present

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -26,14 +26,14 @@ Table = {{ wireguard_table }}
 PreUp = {{ wg_preup }}
 {% endfor %}
 {% endif %}
-{% if wireguard_predown is defined %}
-{% for wg_predown in wireguard_predown %}
-PreDown = {{ wg_predown }}
-{% endfor %}
-{% endif %}
 {% if wireguard_postup is defined %}
 {% for wg_postup in wireguard_postup %}
 PostUp = {{ wg_postup }}
+{% endfor %}
+{% endif %}
+{% if wireguard_predown is defined %}
+{% for wg_predown in wireguard_predown %}
+PreDown = {{ wg_predown }}
 {% endfor %}
 {% endif %}
 {% if wireguard_postdown is defined %}


### PR DESCRIPTION
* The resulting order of WireGuard's hooks should coincide with its lifecycle
* Using FQCNs is recommended by the official Ansible documentation