### PR TITLE
Add non-standard kernel installation for RockyLinux 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,3 +57,14 @@ wireguard_centos7_installation_method: "standard"
 
 # The default seconds to wait for machine to reboot and respond
 wireguard_centos7_kernel_plus_reboot_timeout: "600"
+
+#########################################
+# Settings only relevant for RockyLinux 8
+#########################################
+
+# Set wireguard_rockylinux8_installation_method to "non-standard"
+# to build WireGuard module from source, with wireguard-dkms
+#
+# The default of "standard" will use the standard kernel and
+# the ELRepo module for WireGuard.
+wireguard_rockylinux8_installation_method: "standard"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,11 +62,13 @@ wireguard_centos7_kernel_plus_reboot_timeout: "600"
 # Settings only relevant for RockyLinux 8
 #########################################
 
-# Set wireguard_rockylinux8_installation_method to "dkms"
-# to build WireGuard module from source, with wireguard-dkms.
-# This is required if you use a custom kernel and/or your arch
-# is not x64_64.
+# Set wireguard_rockylinux8_installation_method to "kmod"
+# to force installation with kmod-wireguard from ELRepo.
 #
-# The default of "standard" will install the kernel module
-# with kmod-wireguard from ELRepo.
+# Set wireguard_rockylinux8_installation_method to "dkms"
+# to force building WireGuard module from source, with wireguard-dkms.
+#
+# The default of "standard" will use kmod-wireguard if your arch
+# is x86_64 and you use the official kernel, and fallback
+# to wireguard-dkms installation otherwise.
 wireguard_rockylinux8_installation_method: "standard"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,13 +62,11 @@ wireguard_centos7_kernel_plus_reboot_timeout: "600"
 # Settings only relevant for RockyLinux 8
 #########################################
 
-# Set wireguard_rockylinux8_installation_method to "kmod"
-# to force installation with kmod-wireguard from ELRepo.
-#
 # Set wireguard_rockylinux8_installation_method to "dkms"
-# to force building WireGuard module from source, with wireguard-dkms.
+# to build WireGuard module from source, with wireguard-dkms.
+# This is required if you use a custom kernel and/or your arch
+# is not x64_64.
 #
-# The default of "standard" will use kmod-wireguard if your arch
-# is x86_64 and you use the official kernel, and fallback
-# to wireguard-dkms installation otherwise.
+# The default of "standard" will install the kernel module
+# with kmod-wireguard from ELRepo.
 wireguard_rockylinux8_installation_method: "standard"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,9 +62,11 @@ wireguard_centos7_kernel_plus_reboot_timeout: "600"
 # Settings only relevant for RockyLinux 8
 #########################################
 
-# Set wireguard_rockylinux8_installation_method to "non-standard"
-# to build WireGuard module from source, with wireguard-dkms
+# Set wireguard_rockylinux8_installation_method to "dkms"
+# to build WireGuard module from source, with wireguard-dkms.
+# This is required if you use a custom kernel and/or your arch
+# is not x64_64.
 #
-# The default of "standard" will use the standard kernel and
-# the ELRepo module for WireGuard.
+# The default of "standard" will install the kernel module
+# with kmod-wireguard from ELRepo.
 wireguard_rockylinux8_installation_method: "standard"

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -136,6 +136,16 @@ platforms:
     groups:
       - vpn
       - fedora
+  - name: test-wg-rocky8-non-standard
+    box: generic/rocky8
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.130
+    groups:
+      - vpn
+      - el8
 
 provisioner:
   name: ansible
@@ -211,6 +221,12 @@ provisioner:
         wireguard_port: 51823
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.120"
+      test-wg-rocky8-non-standard:
+        wireguard_address: "10.10.10.130/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "192.168.10.130"
+        wireguard_rockylinux8_installation_method: "non-standard"
 
 scenario:
   name: kvm

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -227,6 +227,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.130"
+        wireguard_rockylinux8_installation_method: "dkms"
 
 scenario:
   name: kvm

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -146,6 +146,7 @@ platforms:
     groups:
       - vpn
       - el8
+      - el8-dkms
 
 provisioner:
   name: ansible
@@ -226,7 +227,6 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.130"
-        wireguard_rockylinux8_installation_method: "dkms"
 
 scenario:
   name: kvm

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -136,7 +136,7 @@ platforms:
     groups:
       - vpn
       - fedora
-  - name: test-wg-rocky8-non-standard
+  - name: test-wg-rocky8-dkms
     box: generic/rocky8
     interfaces:
       - auto_config: true
@@ -221,12 +221,12 @@ provisioner:
         wireguard_port: 51823
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.120"
-      test-wg-rocky8-non-standard:
+      test-wg-rocky8-dkms:
         wireguard_address: "10.10.10.130/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.130"
-        wireguard_rockylinux8_installation_method: "non-standard"
+        wireguard_rockylinux8_installation_method: "dkms"
 
 scenario:
   name: kvm

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -45,3 +45,16 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 3600
+
+- hosts: el8-dkms
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Install ELRepo mainline kernel
+      ansible.builtin.raw: |
+        rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
+        dnf install -y https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm
+        dnf --enablerepo=elrepo-kernel install -y kernel-ml
+      changed_when: false
+      failed_when: false

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -24,8 +24,7 @@
           - "wireguard-tools"
         state: present
   when:
-    - (wireguard_rockylinux8_installation_method == "standard" and ansible_architecture == "x86_64" and ansible_kernel is match("4\.18\.0-.*x86_64")) or
-      (wireguard_rockylinux8_installation_method == "kmod")
+    - wireguard_rockylinux8_installation_method == "standard"
 
 - name: (Rocky Linux 8) Tasks for non-standard kernel
   block:
@@ -54,5 +53,5 @@
           - "wireguard-tools"
         state: present
   when:
-    - (wireguard_rockylinux8_installation_method == "standard" and (ansible_architecture != "x86_64" or ansible_kernel is not match("4\.18\.0-.*x86_64"))) or
-      (wireguard_rockylinux8_installation_method == "dkms")
+    - wireguard_rockylinux8_installation_method == "dkms"
+

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -47,5 +47,5 @@
           - "wireguard-tools"
         state: present
   when:
-    - wireguard_rockylinux8_installation_method == "non-standard"
+    - wireguard_rockylinux8_installation_method == "dkms"
 

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -35,6 +35,12 @@
         name: jdoss/wireguard
         chroot: epel-8-{{ ansible_architecture }}
 
+    - name: (Rocky Linux 8) Install EPEL repository
+      ansible.builtin.yum:
+        name:
+          - epel-release
+        update_cache: true
+
     - name: (Rocky Linux 8) Ensure WireGuard KMOD package is removed
       ansible.builtin.yum:
         name:

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -24,7 +24,8 @@
           - "wireguard-tools"
         state: present
   when:
-    - wireguard_rockylinux8_installation_method == "standard"
+    - (wireguard_rockylinux8_installation_method == "standard" and ansible_architecture == "x86_64" and ansible_kernel is match("4\.18\.0-.*x86_64")) or
+      (wireguard_rockylinux8_installation_method == "kmod")
 
 - name: (Rocky Linux 8) Tasks for non-standard kernel
   block:
@@ -47,5 +48,5 @@
           - "wireguard-tools"
         state: present
   when:
-    - wireguard_rockylinux8_installation_method == "dkms"
-
+    - (wireguard_rockylinux8_installation_method == "standard" and (ansible_architecture != "x86_64" or ansible_kernel is not match("4\.18\.0-.*x86_64"))) or
+      (wireguard_rockylinux8_installation_method == "dkms")

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -2,22 +2,50 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: (Rocky Linux 8) Install EPEL & ELRepo repository
-  ansible.builtin.yum:
-    name:
-      - epel-release
-      - elrepo-release
-    update_cache: true
+- name: (Rocky Linux 8) Tasks for standard kernel
+  block:
+    - name: (Rocky Linux 8) Install EPEL & ELRepo repository
+      ansible.builtin.yum:
+        name:
+          - epel-release
+          - elrepo-release
+        update_cache: true
 
-- name: (Rocky Linux 8) Ensure WireGuard DKMS package is removed
-  ansible.builtin.yum:
-    name:
-      - "wireguard-dkms"
-    state: absent
+    - name: (Rocky Linux 8) Ensure WireGuard DKMS package is removed
+      ansible.builtin.yum:
+        name:
+          - "wireguard-dkms"
+        state: absent
 
-- name: (Rocky Linux 8) Install WireGuard packages
-  ansible.builtin.yum:
-    name:
-      - "kmod-wireguard"
-      - "wireguard-tools"
-    state: present
+    - name: (Rocky Linux 8) Install WireGuard packages
+      ansible.builtin.yum:
+        name:
+          - "kmod-wireguard"
+          - "wireguard-tools"
+        state: present
+  when:
+    - wireguard_rockylinux8_installation_method == "standard"
+
+- name: (Rocky Linux 8) Tasks for non-standard kernel
+  block:
+    - name: (Rocky Linux 8) Install jdoss/wireguard COPR repository
+      community.general.copr:
+        state: enabled
+        name: jdoss/wireguard
+        chroot: epel-8-{{ ansible_architecture }}
+
+    - name: (Rocky Linux 8) Ensure WireGuard KMOD package is removed
+      ansible.builtin.yum:
+        name:
+          - "kmod-wireguard"
+        state: absent
+
+    - name: (Rocky Linux 8) Install WireGuard packages
+      ansible.builtin.yum:
+        name:
+          - "wireguard-dkms"
+          - "wireguard-tools"
+        state: present
+  when:
+    - wireguard_rockylinux8_installation_method == "non-standard"
+


### PR DESCRIPTION
Hello, I've been toying with RockyLinux on Raspberry 3 (`aarch64`) and needed the [non-standard kernel](https://www.wireguard.com/install/) installation, as documented by wireguard.

Although my use case is very specific, it should work with any custom kernel on `aarch64`, `ppc64le` and `x86_64`.  
It might also work on AlmaLinux (not tested)

I expanded on the logic you had for CentOS7 setup with a new variable : wireguard_rockylinux8_installation_method, defaulting to the classic EPEL/Elrepo installation process.