### PR TITLE
honor wireguard_save_config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 9.0.1
+
+- FIX: The template rendering the WireGuard configuration only checked if `wireguard_save_config` was set and if so sets `SaveConfig = true`. So setting `wireguard_save_config: "false"` had no effect.
+
 ## 9.0.0
 
 - set minimally required Ansible version to `2.9` (contribution by @8ware)

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -42,7 +42,7 @@ PostDown = {{ wg_postdown }}
 {% endfor %}
 {% endif %}
 {% if wireguard_save_config is defined %}
-SaveConfig = true
+SaveConfig = {{ wireguard_save_config }}
 {% endif %}
 {% for host in ansible_play_hosts %}
 {%   if host != inventory_hostname %}


### PR DESCRIPTION
ATM the template rendering the WireGuard configuration only checks if `wireguard_save_config` is set and if so sets `SaveConfig = true`. So setting `wireguard_save_config: "false"` had no effect. This PR fixes this behavior.

Fixes https://github.com/githubixx/ansible-role-wireguard/issues/136