### PR TITLE
Allow user customize wg.conf file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ wireguard_port: "51820"
 # The default interface name that WireGuard should use if not specified otherwise.
 wireguard_interface: "wg0"
 
+# The template for wg.conf file (default is provided with the role)
+wireguard_conf_template: etc/wireguard/wg.conf.j2
+
 # The default owner of the wg.conf file
 wireguard_conf_owner: root
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,7 +124,7 @@
 
 - name: Generate WireGuard configuration file
   ansible.builtin.template:
-    src: etc/wireguard/wg.conf.j2
+    src: "{{ wireguard_conf_template }}"
     dest: "{{ wireguard_remote_directory }}/{{ wireguard_interface }}.conf"
     owner: "{{ wireguard_conf_owner }}"
     group: "{{ wireguard_conf_group }}"


### PR DESCRIPTION
Now etc/wireguard/wg.conf.j2 template is hardcoded into the role. This PR proposes allow user change the template to implement some custom network layout.
Unortunately, it is impossible in Ansible without changing the role, see:
https://stackoverflow.com/questions/55742881/is-there-a-way-to-override-a-template-defined-into-an-ansible-galaxy-role