### PR TITLE
Introduce config switch for specifying the interface restart behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ wireguard_conf_group: "{{ 'root' if not ansible_os_family == 'Darwin' else 'whee
 # The default mode of the wg.conf file
 wireguard_conf_mode: 0600
 
+# Which method should be used to apply new wireguard configurations?
+# Possible options:
+#   sync: Does make use of the `wg syncconf` command, connections are not interrupted but it does
+#         populate route changes to the interface. Not available on older kernels / systems.
+#   restart: Performs a full restart on the interface. Does interrupt the connections shortly.
+#   undefined: Use sync on systems where it is available, otherwise use restart. (default)
+# wireguard_interface_restart_behavior:
+
 # The default state of the wireguard service
 wireguard_service_enabled: "yes"
 wireguard_service_state: "started"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,14 @@ wireguard_conf_mode: 0600
 wireguard_service_enabled: "yes"
 wireguard_service_state: "started"
 
+# Which method should be used to apply new wireguard configurations?
+# Possible options:
+#   sync: Does make use of the `wg syncconf` command, connections are not interrupted but it does
+#         populate route changes to the interface. Not available on older kernels / systems.
+#   restart: Performs a full restart on the interface. Does interrupt the connections shortly.
+#   undefined: Use sync on systems where it is available, otherwise use restart. (default)
+# wireguard_interface_restart_behavior:
+
 # This is sensitive: encrypt it with a tool like Ansible Vault.
 # If not set, a new one is generated on a blank configuration.
 # wireguard_private_key:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,7 +10,7 @@
     - stopped
     - started
   when:
-    - not wg_syncconf
+    - not use_wg_syncconf
     - not ansible_os_family == 'Darwin'
     - wireguard_service_enabled == "yes"
   listen: "reconfigure wireguard"
@@ -26,7 +26,7 @@
   args:
     executable: "/bin/bash"
   when:
-    - wg_syncconf
+    - use_wg_syncconf
     - not ansible_os_family == 'Darwin'
     - wireguard_service_enabled == "yes"
   listen: "reconfigure wireguard"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,14 +45,24 @@
       register: wireguard__register_subcommands
       changed_when: false
       check_mode: false
+      when:
+        - wireguard_interface_restart_behavior is not defined
 
     - name: Check if wg syncconf subcommand is available
       ansible.builtin.set_fact:
-        wg_syncconf: "{{ 'syncconf:' in wireguard__register_subcommands.stdout }}"
+        use_wg_syncconf: "{{ 'syncconf:' in wireguard__register_subcommands.stdout }}"
+      when:
+        - wireguard_interface_restart_behavior is not defined
+
+    - name: Set whether wg syncconf should get used to apply interface changes
+      ansible.builtin.set_fact:
+        use_wg_syncconf: "{{ wireguard_interface_restart_behavior == 'sync' }}"
+      when:
+        - wireguard_interface_restart_behavior is defined
 
     - name: Show syncconf subcommand status
       ansible.builtin.debug:
-        var: wg_syncconf
+        var: use_wg_syncconf
   tags:
     - wg-generate-keys
     - wg-config


### PR DESCRIPTION
This change was made in order to enable the possibility to ensure e.g. routes of the Wireguard interface get properly reloaded when they change while sacrificing uninterrupted interfaces.

I still would argue that most users would want the properly reloaded interfaces instead of an fully uninterrupted interface by default as when having e.g. no proper routes set it is quite hard to detect. Even more, simply restarting the server / interface does fix the issue, which makes it even harder to debug if users are not too familiar with how Wireguard configuration works.

I know that changing the default behavior would be a breaking change but I believe this change would not affect / be noticeable for many users. If you agree I will change the PR so the default is `restart` instead of auto-detect.

Fixes #147 