### PR TITLE
Prefix host name comment with 'Name =' for wg-info

### DIFF
--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -48,7 +48,7 @@ SaveConfig = {{ wireguard_save_config }}
 {%   if host != inventory_hostname %}
 
 [Peer]
-# {{ host }}
+# Name = {{ host }}
 PublicKey = {{hostvars[host].wireguard__fact_public_key}}
 {%     if hostvars[host].wireguard_allowed_ips is defined %}
 AllowedIPs = {{hostvars[host].wireguard_allowed_ips}}

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -87,7 +87,7 @@ Endpoint = {{host}}:{{wireguard_port}}
 # Peers not managed by Ansible from "wireguard_unmanaged_peers" variable
 {% for peer in wireguard_unmanaged_peers.keys() %}
 [Peer]
-# {{ peer }}
+# Name = {{ peer }}
 PublicKey = {{ wireguard_unmanaged_peers[peer].public_key }}
 {%     if wireguard_unmanaged_peers[peer].preshared_key is defined %}
 PresharedKey = {{ wireguard_unmanaged_peers[peer].preshared_key }}


### PR DESCRIPTION
Adds the `Name = ` prefix in host name comment line of wireguard config to allow this [wg-info](https://github.com/asdil12/wg-info) neat little script to display host name.