### PR TITLE
Add `wireguard_unmanaged_peers_only` to keep the module from managing peers and public|private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Now this is basically the same as above BUT now the config says: I want to route
 
 You can specify further optional settings (they don't have a default and won't be set if not specified besides `wireguard_allowed_ips` as already mentioned) also per host in `host_vars/` (or in your Ansible hosts file if you like). The values for the following variables are just examples and no defaults (for more information and examples see [wg-quick.8](https://git.zx2c4.com/WireGuard/about/src/tools/man/wg-quick.8)):
 
+Setting `wireguard_unmanaged_peers_only` to true, will keep the module from creating and managing the peers for you.
+
 ```yaml
 wireguard_allowed_ips: ""
 wireguard_endpoint: "host1.domain.tld"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,10 @@ wireguard_interface_restart: false
 # If not set, a new one is generated on a blank configuration.
 # wireguard_private_key:
 
+# Setting this to true, will make this module don't automatically create any
+# peers. You'll have to manually define `wireguard_unmanaged_peers`.
+wireguard_unmanaged_peers_only: false
+
 #######################################
 # Settings only relevant for Ubuntu
 #######################################

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,6 +126,8 @@
         - wg-config
 
 - name: Derive WireGuard public key
+  when:
+    - not wireguard_unmanaged_peers_only
   ansible.builtin.command: "wg pubkey"
   args:
     stdin: "{{ wireguard_private_key }}"
@@ -137,6 +139,8 @@
     - wg-config
 
 - name: Set public key fact
+  when:
+    - not wireguard_unmanaged_peers_only
   ansible.builtin.set_fact:
     wireguard__fact_public_key: "{{ wireguard__register_public_key.stdout }}"
   tags:

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -44,44 +44,46 @@ PostDown = {{ wg_postdown }}
 {% if wireguard_save_config is defined %}
 SaveConfig = {{ wireguard_save_config }}
 {% endif %}
-{% for host in ansible_play_hosts %}
-{%   if host != inventory_hostname %}
+{% if wireguard_unmanaged_peers_only == false %}
+{%   for host in ansible_play_hosts %}
+{%     if host != inventory_hostname %}
 
 [Peer]
 # {{ host }}
 PublicKey = {{hostvars[host].wireguard__fact_public_key}}
-{%     if hostvars[host].wireguard_allowed_ips is defined %}
+{%       if hostvars[host].wireguard_allowed_ips is defined %}
 AllowedIPs = {{hostvars[host].wireguard_allowed_ips}}
-{%     else %}
+{%       else %}
 AllowedIPs = {{ hostvars[host].wireguard_address.split('/')[0] }}/32
-{%     endif %}
-{%     if hostvars[host].wireguard_persistent_keepalive is defined %}
+{%       endif %}
+{%       if hostvars[host].wireguard_persistent_keepalive is defined %}
 PersistentKeepalive = {{hostvars[host].wireguard_persistent_keepalive}}
-{%     endif %}
-{%     if (
+{%       endif %}
+{%       if (
          hostvars[host].wireguard_dc is defined and
          wireguard_dc is defined and
          wireguard_dc['name'] != hostvars[host].wireguard_dc['name']
        )
 %}
 Endpoint = {{hostvars[host].wireguard_dc['endpoint']}}:{{hostvars[host].wireguard_dc['port']}}
-{%     elif hostvars[host].wireguard_port is defined %}
-{%       if hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "" %}
+{%       elif hostvars[host].wireguard_port is defined %}
+{%         if hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "" %}
 Endpoint = {{hostvars[host].wireguard_endpoint}}:{{hostvars[host].wireguard_port}}
-{%       else %}
+{%         else %}
 Endpoint = {{host}}:{{hostvars[host].wireguard_port}}
-{%       endif %}
-{%     elif hostvars[host].wireguard_endpoint is defined %}
-{%       if hostvars[host].wireguard_endpoint != "" %}
+{%         endif %}
+{%       elif hostvars[host].wireguard_endpoint is defined %}
+{%         if hostvars[host].wireguard_endpoint != "" %}
 Endpoint = {{hostvars[host].wireguard_endpoint}}:{{wireguard_port}}
-{%       else %}
+{%         else %}
 # No endpoint defined for this peer
-{%       endif %}
-{%     else %}
+{%         endif %}
+{%       else %}
 Endpoint = {{host}}:{{wireguard_port}}
+{%       endif %}
 {%     endif %}
-{%   endif %}
-{% endfor %}
+{%   endfor %}
+{% endif %}
 {% if wireguard_unmanaged_peers is defined %}
 
 # Peers not managed by Ansible from "wireguard_unmanaged_peers" variable


### PR DESCRIPTION
Should fix #165 