### PR TITLE
Rocky Linux + AlmaLinux support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 11.0.0
+
+- add support for Rocky Linux 9 (original PR from @vincentDcmps: https://github.com/githubixx/ansible-role-wireguard/pull/163)
+- add support for AlamaLinux 9 (original PR from @trunet: https://github.com/githubixx/ansible-role-wireguard/pull/164)
+- add `EL9` to `meta/main.yml`
+- require Ansible >= `2.11` as Rocky Linux is only supported with this version or above
+- `ansible-lint`: use `community.general.pacman` module instead of `ansible.builtin.pacman` for Archlinux setup
+
 ## 10.0.0
 
 - remove Fedora 34 + add Fedora 36 to Molecule test

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This role should work with:
 - AlmaLinux
 - Rocky Linux
 - openSUSE Leap 15.3
+- openSUSE Leap 15.4
 
 Molecule tests are [available](https://github.com/githubixx/ansible-role-wireguard#testing) (see further down below). It should also work with `Raspbian Buster` but for this one there is no test available. MacOS (see below) should also work partitially but is only best effort.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,7 @@ galaxy_info:
       versions:
         - "7"
         - "8"
+        - "9"
     - name: Fedora
       versions:
         - "35"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   author: Robert Wimmer
   description: Installs Wireguard incl. systemd integration
   license: GPL-3.0-or-later
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.11"
   namespace: githubixx
   role_name: ansible_role_wireguard
   platforms:

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -194,6 +194,30 @@ platforms:
     groups:
       - vpn
       - opensuse
+  - name: test-wg-rocky9
+    box: generic/rocky9
+    memory: 1024
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.160
+    groups:
+      - vpn
+      - el9
+  - name: test-wg-alma9
+    box: generic/alma9
+    memory: 1024
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.170
+    groups:
+      - vpn
+      - el9
 
 provisioner:
   name: ansible
@@ -287,6 +311,16 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.150"
+      test-wg-rocky9:
+        wireguard_address: "10.10.10.160/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "192.168.10.160"
+      test-wg-alma9:
+        wireguard_address: "10.10.10.170/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "192.168.10.170"
 
 scenario:
   name: kvm

--- a/tasks/setup-almalinux.yml
+++ b/tasks/setup-almalinux.yml
@@ -1,0 +1,8 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: (AlmaLinux) Install wireguard-tools package
+  ansible.builtin.yum:
+    name: wireguard-tools
+    state: present

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Archlinux) Install wireguard-tools package
-  ansible.builtin.pacman:
+  community.general.pacman:
     name: wireguard-tools
     state: present

--- a/tasks/setup-rocky.yml
+++ b/tasks/setup-rocky.yml
@@ -1,0 +1,8 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: (Rocky Linux) Install wireguard-tools package
+  ansible.builtin.yum:
+    name: wireguard-tools
+    state: present


### PR DESCRIPTION
- add support for Rocky Linux 9 (original PR from @vincentDcmps: https://github.com/githubixx/ansible-role-wireguard/pull/163)
- add support for AlamaLinux 9 (original PR from @trunet: https://github.com/githubixx/ansible-role-wireguard/pull/164)
- add `EL9` to `meta/main.yml`
- require Ansible >= `2.11` as Rocky Linux is only supported with this version or above
- `ansible-lint`: use `community.general.pacman` module instead of `ansible.builtin.pacman` for Archlinux setup