### PR TITLE
install Systemd resolved in rocky

### DIFF
--- a/tasks/setup-rocky.yml
+++ b/tasks/setup-rocky.yml
@@ -6,3 +6,16 @@
   ansible.builtin.yum:
     name: wireguard-tools
     state: present
+
+- name: Install Systemd-resolved package if DNS is set
+  block: 
+    - name: install Systemd-resolved 
+      ansible.builtin.yum:
+        name: systemd-resolved
+        state: present
+    - name: enable Systemd-resolved
+      ansible.builtin.service:
+        name: systemd-resolved
+        state: started
+        enabled: true
+  when: wireguard_dns is defined


### PR DESCRIPTION
when use 'wireguard_dns' variable in rocky 9 you get an error on wireguard start because resovconf not exist.
I propose to install systemd-resolved has a workaround only when 'wireguard_dns' variable is defined
