### PR TITLE
Allow to use multiple addresses and added IPv6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 13.0.0
+
+- add IPv6 support (contribution by @DiscowZombie)
+- introduce `wireguard_addresses` variable (contribution by @DiscowZombie)
+
 ## 12.0.0
 
 - remove Fedora 35 support (reached EOL)

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -6,7 +6,7 @@
 
 [Interface]
 # {{ inventory_hostname }}
-Address = {{ wireguard_address }}
+Address = {{ wireguard_address }}{% if wireguard_address_v6 is defined %}, {{ wireguard_address_v6 }}{% endif %} 
 PrivateKey = {{ wireguard_private_key }}
 ListenPort = {{ wireguard_port }}
 {% if wireguard_dns is defined %}
@@ -53,7 +53,7 @@ PublicKey = {{hostvars[host].wireguard__fact_public_key}}
 {%     if hostvars[host].wireguard_allowed_ips is defined %}
 AllowedIPs = {{hostvars[host].wireguard_allowed_ips}}
 {%     else %}
-AllowedIPs = {{ hostvars[host].wireguard_address.split('/')[0] }}/32
+AllowedIPs = {{ hostvars[host].wireguard_address.split('/')[0] }}/32{% if hostvars[host].wireguard_address_v6 is defined %}, {{hostvars[host].wireguard_address_v6.split('/')[0]}}/128{% endif %} 
 {%     endif %}
 {%     if hostvars[host].wireguard_persistent_keepalive is defined %}
 PersistentKeepalive = {{hostvars[host].wireguard_persistent_keepalive}}

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -6,7 +6,14 @@
 
 [Interface]
 # {{ inventory_hostname }}
-Address = {{ wireguard_address }}{% if wireguard_address_v6 is defined %}, {{ wireguard_address_v6 }}{% endif %} 
+{% if wireguard_address is defined %}
+Address = {{ wireguard_address }}
+{% endif %}
+{% if wireguard_addresses is defined %}
+{%  for wg_addr in wireguard_addresses %}
+Address = {{ wg_addr }}
+{%  endfor %}
+{% endif %}
 PrivateKey = {{ wireguard_private_key }}
 ListenPort = {{ wireguard_port }}
 {% if wireguard_dns is defined %}
@@ -53,7 +60,18 @@ PublicKey = {{hostvars[host].wireguard__fact_public_key}}
 {%     if hostvars[host].wireguard_allowed_ips is defined %}
 AllowedIPs = {{hostvars[host].wireguard_allowed_ips}}
 {%     else %}
-AllowedIPs = {{ hostvars[host].wireguard_address.split('/')[0] }}/32{% if hostvars[host].wireguard_address_v6 is defined %}, {{hostvars[host].wireguard_address_v6.split('/')[0]}}/128{% endif %} 
+{%      if wireguard_address is defined %}
+AllowedIPs = {{ hostvars[host].wireguard_address.split('/')[0] }}/32
+{%      endif %}
+{%      if wireguard_addresses is defined %}
+{%      for wg_addr in hostvars[host].wireguard_addresses %}
+{%        if (wg_addr | ansible.utils.ipv4) %}
+AllowedIPs = {{ wg_addr.split('/')[0] }}/32
+{%        elif (wg_addr | ansible.utils.ipv6) %}
+AllowedIPs = {{ wg_addr.split('/')[0] }}/128
+{%        endif %}
+{%      endfor %}
+{%      endif %}
 {%     endif %}
 {%     if hostvars[host].wireguard_persistent_keepalive is defined %}
 PersistentKeepalive = {{hostvars[host].wireguard_persistent_keepalive}}


### PR DESCRIPTION
First of all, thanks for the great work, this role was really useful for one of my project.

## Current limitations

Until now, it has been impossible for a host to have multiple IPs inside the VPN. This prevents a lot of use-cases, especially dual-stack network (one IPv4 and one IPv6). Furthermore, putting an IPv6 inside the `wireguard_address` produced an invalid configuration file, since the IP got suffixed by the `/32` mask : 
https://github.com/githubixx/ansible-role-wireguard/blob/f6a6e4680a6061622bee2351daadaa30f60f953d/templates/etc/wireguard/wg.conf.j2#L56

This PR aims to fix IPv6 support and allow using multiple IPs.

To do this, the PR implements the `wireguard_addresses` variable. This variable can contain an array of IPv4 or IPv6 addresses to be used inside the Wireguard network. The old way of specifying one IPv4 (through the `wireguard_address` variable) is still supported, even I recommend migrating to the new `wireguard_addresses` variable.

## Examples

Consider three nodes, `ansible1`, `ansible2` and `ansible3`.

### IPv4 only network

#### Old way (still working)

`hosts.yaml`
```yaml
all:
  hosts:
    ansible1:
      # Variables such as ansible_host have been removed
      wireguard_endpoint: "ansible1.public.tld"
      wireguard_address: "10.8.0.1/24"
    ansible2:
      wireguard_endpoint: "ansible2.public.tld"
      wireguard_address: "10.8.0.2/24"
    ansible3:
      wireguard_endpoint: "ansible3.public.tld"
      wireguard_address: "10.8.0.3/24"
```

#### New way

`hosts.yaml`
```yaml
all:
  hosts:
    ansible1:
      # Variables such as ansible_host have been removed
      wireguard_endpoint: "ansible1.public.tld"
      wireguard_addresses: 
        - "10.8.0.1/24"
    ansible2:
      wireguard_endpoint: "ansible2.public.tld"
      wireguard_addresses: 
        - "10.8.0.2/24"
    ansible3:
      wireguard_endpoint: "ansible3.public.tld"
      wireguard_addresses: 
        - "10.8.0.3/24"
```

### Dual-stack network

`hosts.yaml`
```yaml
all:
  hosts:
    ansible1:
      # Variables such as ansible_host have been removed
      wireguard_endpoint: "ansible1.public.tld"
      wireguard_addresses: 
        - "10.8.0.1/24"
        - "fd0d:1234:5678::1/64"
    ansible2:
      wireguard_endpoint: "ansible2.public.tld"
      wireguard_addresses: 
        - "10.8.0.2/24"
        - "fd0d:1234:5678::2/64"
    ansible3:
      wireguard_endpoint: "ansible3.public.tld"
      wireguard_addresses: 
        - "10.8.0.3/24"
        - "fd0d:1234:5678::3/64"
```

### Complex network

A more complex network example.

`hosts.yaml`
```yaml
all:
  hosts:
    ansible1:
      # Variables such as ansible_host have been removed
      wireguard_endpoint: "ansible1.public.tld"
      wireguard_addresses: 
        - "10.8.0.1/24"
        - "10.10.0.1/23"
        - "fd0d:1234:5678::1/64"
    ansible2:
      wireguard_endpoint: "ansible2.public.tld"
      wireguard_addresses: 
        - "10.8.0.2/24"
    ansible3:
      wireguard_endpoint: "ansible3.public.tld"
      wireguard_addresses: 
        - "10.8.0.3/24"
        - "10.10.1.3/23"
        - "fd0d:1234:5678::3/64"
```

## Testing and other notes

All those setups have been tested with [multipass](https://multipass.run). If I have time, I will be happy to experiment with molecule too. I would be happy if some could experiment on their side too (and give inputs).

All the changes have been designed to be backward compatible.

If you plan merging this PR, let me know, since the readme will benefit from an update to explain the new variable too.

FYI: During my testing, I tried using an IPv6 as `Endpoint` and can confirm it (already) work.