### PR TITLE
Fixed unsetting the Wireguard endpoint whilst using a custom port

### DIFF
--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -66,8 +66,12 @@ PersistentKeepalive = {{hostvars[host].wireguard_persistent_keepalive}}
 %}
 Endpoint = {{hostvars[host].wireguard_dc['endpoint']}}:{{hostvars[host].wireguard_dc['port']}}
 {%     elif hostvars[host].wireguard_port is defined %}
-{%       if hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "" %}
+{%       if hostvars[host].wireguard_endpoint is defined %}
+{%         if hostvars[host].wireguard_endpoint != "" %}
 Endpoint = {{hostvars[host].wireguard_endpoint}}:{{hostvars[host].wireguard_port}}
+{%         else %}
+# No endpoint defined for this peer
+{%         endif %}
 {%       else %}
 Endpoint = {{host}}:{{hostvars[host].wireguard_port}}
 {%       endif %}


### PR DESCRIPTION
Closes #176 

It's a very small contribution but it was something I just noticed when I set a custom port and wanted to have one of my nodes to not have an endpoint listed.