### PR TITLE
option wireguard_update_cache to disable refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 13.1.0
+- new variable `wireguard_update_cache` to control if package manager caches should be updated before the installation (https://github.com/githubixx/ansible-role-wireguard/pull/179)
+ - variable `wireguard_ubuntu_update_cache` is deprecated and will be removed in the next release
+
 ## 13.0.1
 
 - [fix](https://github.com/githubixx/ansible-role-wireguard/pull/182) in README

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ wireguard_interface_restart: false
 # course a very sensitive value you might consider a tool like Ansible Vault
 # to store it encrypted.
 # wireguard_private_key:
+
+# Set to "false" if package cache should not be updated
+wireguard_update_cache: "true"
 ```
 
 There are also a few Linux distribution specific settings:
@@ -148,8 +151,9 @@ There are also a few Linux distribution specific settings:
 # - elementary OS
 #######################################
 
-# Set to "false" if package cache should not be updated
-wireguard_ubuntu_update_cache: "true"
+# Set to "false" if package cache should not be updated.
+# DEPRECATED: This variable will be removed with the next major release. Please use "wireguard_update_cache" instead.
+wireguard_ubuntu_update_cache: "{{ wireguard_update_cache }}"
 
 # Set package cache valid time
 wireguard_ubuntu_cache_valid_time: "3600"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,9 @@ wireguard_interface_restart: false
 #######################################
 
 # Set to "false" if package cache should not be updated
-wireguard_ubuntu_update_cache: "true"
+wireguard_update_cache: "true"
+# DEPRECATED: This variable will be removed with the next major release. Please use "wireguard_update_cache" instead.
+wireguard_ubuntu_update_cache: "{{ wireguard_update_cache }}"
 
 # Set package cache valid time
 wireguard_ubuntu_cache_valid_time: "3600"

--- a/tasks/setup-almalinux-8.yml
+++ b/tasks/setup-almalinux-8.yml
@@ -7,7 +7,7 @@
     name:
       - epel-release
       - elrepo-release
-    update_cache: true
+    update_cache: "{{ wireguard_update_cache }}"
 
 - name: (AlmaLinux 8) Ensure WireGuard DKMS package is removed
   ansible.builtin.yum:

--- a/tasks/setup-centos-7.yml
+++ b/tasks/setup-centos-7.yml
@@ -11,12 +11,12 @@
         name:
           - epel-release
           - https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
-        update_cache: true
+        update_cache: "{{ wireguard_update_cache }}"
 
     - name: (CentOS 7) Install yum-plugin-elrepo
       ansible.builtin.yum:
         name: yum-plugin-elrepo
-        update_cache: true
+        update_cache: "{{ wireguard_update_cache }}"
 
     - name: (CentOS 7) Install WireGuard packages
       ansible.builtin.yum:
@@ -40,7 +40,7 @@
         name:
           - epel-release
           - yum-utils
-        update_cache: true
+        update_cache: "{{ wireguard_update_cache }}"
 
     - name: (CentOS 7) Enable CentosPlus repo
       ansible.builtin.command: yum-config-manager --setopt=centosplus.includepkgs=kernel-plus --enablerepo=centosplus --save

--- a/tasks/setup-debian-pve-guest-variant.yml
+++ b/tasks/setup-debian-pve-guest-variant.yml
@@ -6,7 +6,7 @@
   ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: "{{ 'present' if (ansible_distribution_version | int <= 10) else 'absent' }}"
-    update_cache: true
+    update_cache: "{{ wireguard_update_cache }}"
 
 - name: (Proxmox lxc) Install wireguard-tools.
   ansible.builtin.apt:

--- a/tasks/setup-debian-pve-host-variant.yml
+++ b/tasks/setup-debian-pve-host-variant.yml
@@ -8,7 +8,7 @@
   ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: "{{ 'present' if (ansible_distribution_version | int <= 10) else 'absent' }}"
-    update_cache: true
+    update_cache: "{{ wireguard_update_cache }}"
 
 - name: (Proxmox) Install kernel headers for the currently running kernel to compile WireGuard with DKMS
   ansible.builtin.apt:

--- a/tasks/setup-debian-raspbian-buster.yml
+++ b/tasks/setup-debian-raspbian-buster.yml
@@ -27,7 +27,7 @@
   ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian buster-backports main"
     state: present
-    update_cache: true
+    update_cache: "{{ wireguard_update_cache }}"
 
 - name: (Raspbian) Install latest kernel
   ansible.builtin.apt:

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -8,3 +8,4 @@
     name:
       - "wireguard"
     state: present
+    update_cache: "{{ wireguard_update_cache }}"

--- a/tasks/setup-rocky-8.yml
+++ b/tasks/setup-rocky-8.yml
@@ -11,7 +11,7 @@
         name:
           - epel-release
           - elrepo-release
-        update_cache: true
+        update_cache: "{{ wireguard_update_cache }}"
 
     - name: (Rocky Linux 8) Ensure WireGuard DKMS package is removed
       ansible.builtin.yum:
@@ -40,7 +40,7 @@
       ansible.builtin.yum:
         name:
           - epel-release
-        update_cache: true
+        update_cache: "{{ wireguard_update_cache }}"
 
     - name: (Rocky Linux 8) Ensure WireGuard KMOD package is removed
       ansible.builtin.yum:


### PR DESCRIPTION
previously disable the cache update was only possible on ubuntu using the generic name wireguard_update_cache it can be enabled for all operating systems