### PR TITLE
12.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 12.0.0
+
+- remove Fedora 35 support (reached EOL)
+- remove openSUSE 15.3 support (reached EOL)
+- remove Debian 10 (Buster) support (readed EOL)
+- fix Molecule prepare for Archlinux
+- fix `ansible-lint` issue in `tasks/setup-debian-raspbian-buster.yml`
+
 ## 11.1.0
 
 - add support for elementary OS 6

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ This role should work with:
 - Ubuntu 20.04 (Focal Fossa)
 - Ubuntu 22.04 (Jammy Jellyfish)
 - Archlinux
-- Debian 10 (Buster)
 - Debian 11 (Bullseye)
 - Fedora 34 (or later)
 - CentOS 7
 - AlmaLinux
 - Rocky Linux
-- openSUSE Leap 15.3
 - openSUSE Leap 15.4
 
 Best effort:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This role should work with:
 - Ubuntu 22.04 (Jammy Jellyfish)
 - Archlinux
 - Debian 11 (Bullseye)
-- Fedora 34 (or later)
+- Fedora 36
 - CentOS 7
 - AlmaLinux
 - Rocky Linux

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,7 +26,6 @@ galaxy_info:
         - "9"
     - name: Fedora
       versions:
-        - "35"
         - "36"
     - name: opensuse
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,7 @@ galaxy_info:
         - "36"
     - name: opensuse
       versions:
-        - "15.3"
+        - "15.4"
   galaxy_tags:
     - networking
     - security

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,7 +18,6 @@ galaxy_info:
         - "jammy"
     - name: Debian
       versions:
-        - "buster"
         - "bullseye"
     - name: EL
       versions:

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -121,18 +121,6 @@ platforms:
     groups:
       - vpn
       - el7
-  - name: test-wg-opensuse-leap-15-3
-    box: opensuse/Leap-15.3.x86_64
-    memory: 1024
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.110
-    groups:
-      - vpn
-      - opensuse
   - name: test-wg-fedora35
     box: generic/fedora35
     memory: 1024
@@ -267,11 +255,6 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.100"
         wireguard_centos7_installation_method: "kernel-plus"
-      test-wg-opensuse-leap-15-3:
-        wireguard_address: "10.10.10.110/24"
-        wireguard_port: 51822
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.110"
       test-wg-fedora35:
         wireguard_address: "10.10.10.120/24"
         wireguard_port: 51823

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -121,18 +121,6 @@ platforms:
     groups:
       - vpn
       - el7
-  - name: test-wg-fedora35
-    box: generic/fedora35
-    memory: 1024
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.120
-    groups:
-      - vpn
-      - fedora
   - name: test-wg-rocky8-dkms
     box: generic/rocky8
     memory: 1024
@@ -255,11 +243,6 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.100"
         wireguard_centos7_installation_method: "kernel-plus"
-      test-wg-fedora35:
-        wireguard_address: "10.10.10.120/24"
-        wireguard_port: 51823
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.120"
       test-wg-rocky8-dkms:
         wireguard_address: "10.10.10.130/24"
         wireguard_port: 51820

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -37,18 +37,6 @@ platforms:
     groups:
       - vpn
       - ubuntu
-  - name: test-wg-debian10
-    box: generic/debian10
-    memory: 1024
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.30
-    groups:
-      - vpn
-      - debian
   - name: test-wg-fedora36
     box: generic/fedora36
     memory: 1024
@@ -239,12 +227,6 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.20"
-      test-wg-debian10:
-        wireguard_address: "10.10.10.30/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.30"
-        ansible_python_interpreter: "/usr/bin/python"
       test-wg-fedora36:
         wireguard_address: "10.10.10.40/24"
         wireguard_port: 51820

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -17,7 +17,7 @@
 - hosts: archlinux
   remote_user: vagrant
   become: true
-  gather_facts: true
+  gather_facts: false
   tasks:
     - name: Init pacman
       ansible.builtin.raw: |
@@ -25,6 +25,13 @@
         pacman-key --populate archlinux
       changed_when: false
       failed_when: false
+
+    - name: Install Python
+      ansible.builtin.raw: |
+        pacman -S --noconfirm python
+      args:
+        executable: /bin/bash
+      changed_when: false
 
 - hosts: proxmox
   remote_user: vagrant

--- a/tasks/setup-debian-raspbian-buster.yml
+++ b/tasks/setup-debian-raspbian-buster.yml
@@ -60,6 +60,7 @@
   async: 1
   poll: 0
   ignore_unreachable: true
+  changed_when: false
   when:
     - ansible_version.full is version('2.8.0', '<')
     - wireguard__register_kernel_update is changed

--- a/tasks/setup-debian-vanilla.yml
+++ b/tasks/setup-debian-vanilla.yml
@@ -3,36 +3,6 @@
 # Copyright (C) 2019-2020 Ties de Kock
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: (Debian) Tasks for Debian version <= 10
-  when:
-    - ansible_distribution_major_version is version('11', '<')
-  block:
-    - name: (Debian) Add WireGuard repository on buster
-      ansible.builtin.apt_repository:
-        repo: "deb http://deb.debian.org/debian buster-backports main"
-        state: present
-        update_cache: true
-
-    - name: (Debian) Install kernel headers for the currently running kernel to compile Wireguard with DKMS
-      ansible.builtin.apt:
-        name:
-          - "linux-headers-{{ ansible_kernel }}"
-        state: present
-
-    - name: (Debian) Get architecture
-      ansible.builtin.command: "dpkg --print-architecture"
-      register: wireguard__fact_dpkg_arch
-      changed_when: false
-      check_mode: false
-
-    - name: (Debian) Install kernel headers metapackage to ensure headers will be installed
-      ansible.builtin.apt:
-        name:
-          - "linux-headers-{{ wireguard__fact_dpkg_arch.stdout }}"
-        state: present
-      when:
-        - ('-cloud-' not in ansible_kernel)
-
 - name: (Debian) Install WireGuard packages
   ansible.builtin.apt:
     name:


### PR DESCRIPTION
- remove Fedora 35 support (reached EOL)
- remove openSUSE 15.3 support (reached EOL)
- remove Debian 10 (Buster) support (readed EOL)
- fix Molecule prepare for Archlinux
- fix `ansible-lint` issue in `tasks/setup-debian-raspbian-buster.yml`