### PR TITLE
Add reboot to the standard mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 14.0.0
+
+- add reboot to the standard mode to make sure the WireGuard kernel module is available (contribution by @mofelee)
+
 ## 13.0.1
 
 - [fix](https://github.com/githubixx/ansible-role-wireguard/pull/182) in README

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ wireguard_centos7_installation_method: "standard"
 
 # The default seconds to wait for machine to reboot and respond
 wireguard_centos7_kernel_plus_reboot_timeout: "600"
+wireguard_centos7_standard_reboot_timeout: "600"
 
 #########################################
 # Settings only relevant for RockyLinux 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,6 +94,7 @@ wireguard_centos7_installation_method: "standard"
 
 # The default seconds to wait for machine to reboot and respond
 wireguard_centos7_kernel_plus_reboot_timeout: "600"
+wireguard_centos7_standard_reboot_timeout: "600"
 
 #########################################
 # Settings only relevant for RockyLinux 8

--- a/tasks/setup-centos-7.yml
+++ b/tasks/setup-centos-7.yml
@@ -24,6 +24,13 @@
           - "kmod-wireguard"
           - "wireguard-tools"
         state: present
+      register: wireguard__centos7_yum_updates
+
+    - name: (CentOS 7) Reboot Instance to update kernel
+      ansible.builtin.reboot:
+        reboot_timeout: "{{ wireguard_centos7_standard_reboot_timeout }}"
+      when:
+        - wireguard__centos7_yum_updates.changed is true
 
 - name: (CentOS 7) Ensure WireGuard DKMS package is removed
   ansible.builtin.yum:
@@ -58,11 +65,11 @@
           - "kernel-plus"
           - "wireguard-tools"
         state: present
-      register: centos7_yum_updates
+      register: wireguard__centos7_yum_updates
 
     - name: (CentOS 7) Reboot Instance to update kernel
       ansible.builtin.reboot:
         reboot_timeout: "{{ wireguard_centos7_kernel_plus_reboot_timeout }}"
       when:
-        - centos7_yum_updates.changes is defined
-        - centos7_yum_updates.changes.installed|flatten|select('regex', '^kernel-plus$') is any
+        - wireguard__centos7_yum_updates.changes is defined
+        - wireguard__centos7_yum_updates.changes.installed|flatten|select('regex', '^kernel-plus$') is any


### PR DESCRIPTION
It needs to be rebooted to make the WireGuard kernel module available.