### PR TITLE
Make it possible to use wg-config tag only

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,6 +80,7 @@
       {%- endif %}
   tags:
     - skip_ansible_lint
+    - wg-config
 
 - name: Register if config/private key already exists on target host
   ansible.builtin.stat:


### PR DESCRIPTION
Currently it would fail with "'wireguard__restart_interface' is undefined"