### PR TITLE
Add support for RHEL 8

### DIFF
--- a/tasks/setup-redhat-8.yml
+++ b/tasks/setup-redhat-8.yml
@@ -1,0 +1,20 @@
+---
+- name: (RedHat 8) Install EPEL & ELRepo repository
+  ansible.builtin.yum:
+    name:
+      - epel-release
+      - elrepo-release
+    update_cache: "{{ wireguard_update_cache }}"
+
+- name: (RedHat 8) Ensure WireGuard DKMS package is removed
+  ansible.builtin.yum:
+    name:
+      - "wireguard-dkms"
+    state: absent
+
+- name: (RedHat 8) Install WireGuard packages
+  ansible.builtin.yum:
+    name:
+      - "kmod-wireguard"
+      - "wireguard-tools"
+    state: present

--- a/tasks/setup-redhat-8.yml
+++ b/tasks/setup-redhat-8.yml
@@ -2,8 +2,8 @@
 - name: (RedHat 8) Install EPEL & ELRepo repository
   ansible.builtin.yum:
     name:
-      - epel-release
-      - elrepo-release
+      - https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+      - https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm
     update_cache: "{{ wireguard_update_cache }}"
 
 - name: (RedHat 8) Ensure WireGuard DKMS package is removed

--- a/tasks/setup-redhat-8.yml
+++ b/tasks/setup-redhat-8.yml
@@ -1,4 +1,14 @@
 ---
+- name: (RedHat 8) Install EPEL Release GPG key
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+
+- name: (RedHat 8) Install ELRepo GPG key
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
+
 - name: (RedHat 8) Install EPEL & ELRepo repository
   ansible.builtin.yum:
     name:


### PR DESCRIPTION
This PR adds support for executing the playbook on RHEL 8 based systems. It does not use DKMS and is based on the Alma Linux 8 implementation.

This has been tested on RHEL 8.7.