### PR TITLE
Add support for wireguard_include_peers variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,13 @@ wireguard_unmanaged_peers:
     persistent_keepalive: 0
 ```
 
+If present, the ``wireguard_include_peers`` setting restricts which peers (as hostnames) are included for a particular host. This can be useful when not all nodes can reach each other:
+
+```yaml
+wireguard_include_peers:
+  - client.example.com
+```
+
 One of `wireguard_address` (deprecated) or `wireguard_addresses` (recommended) is required as already mentioned. It's the IPs of the interface name defined with `wireguard_interface` variable (`wg0` by default). Every host needs at least one unique VPN IP of course. If you don't set `wireguard_endpoint` the playbook will use the hostname defined in the `vpn` hosts group (the Ansible inventory hostname). If you set `wireguard_endpoint` to `""` (empty string) that peer won't have a endpoint. That means that this host can only access hosts that have a `wireguard_endpoint`. That's useful for clients that don't expose any services to the VPN and only want to access services on other hosts. So if you only define one host with `wireguard_endpoint` set and all other hosts have `wireguard_endpoint` set to `""` (empty string) that basically means you've only clients besides one which in that case is the WireGuard server. The third possibility is to set `wireguard_endpoint` to some hostname. E.g. if you have different hostnames for the private and public DNS of that host and need different DNS entries for that case setting `wireguard_endpoint` becomes handy. Take for example the IP above: `wireguard_address: "10.8.0.101"`. That's a private IP and I've created a DNS entry for that private IP like `host01.i.domain.tld` (`i` for internal in that case). For the public IP I've created a DNS entry like `host01.p.domain.tld` (`p` for public). The `wireguard_endpoint` needs to be a interface that the other members in the `vpn` group can connect to. So in that case I would set `wireguard_endpoint` to `host01.p.domain.tld` because WireGuard normally needs to be able to connect to the public IP of the other host(s).
 
 ## Example

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -193,6 +193,19 @@ platforms:
     groups:
       - vpn
       - el
+  - name: test-wg-ubuntu2204-include-peers
+    box: githubixx/ubuntu-22.04
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.25
+    groups:
+      - vpn
+      - ubuntu
+      - include_peers
 
 provisioner:
   name: ansible
@@ -291,6 +304,14 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.24"
+      test-wg-ubuntu2204-include-peers:
+        wireguard_address: "10.10.10.25/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.25"
+        wireguard_include_peers:
+          - test-wg-ubuntu2204
+          - test-wg-ubuntu2404
 
 scenario:
   name: default

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -27,7 +27,11 @@
       ansible.builtin.debug:
         var: hosts_count
 
-    - name: There should be as much WireGuard interfaces as hosts in vpn group minus one
+    - name: There should be as many WireGuard interfaces as hosts in vpn group minus one or as defined peers
       ansible.builtin.assert:
         that:
-          - "hosts_count|int -1 == wireguard__interfaces_count.stdout|int"
+          - >
+            (wireguard_include_peers is defined and
+             wireguard__interfaces_count.stdout|int == wireguard_include_peers|length) or
+            (wireguard_include_peers is not defined and
+             hosts_count|int - 1 == wireguard__interfaces_count.stdout|int)

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -54,7 +54,11 @@ PostDown = {{ wg_postdown }}
 SaveConfig = {{ wireguard_save_config }}
 {% endif %}
 {% for host in ansible_play_hosts %}
-{%   if host != inventory_hostname and ((wireguard_as_spoke | default(false)) != true or (hostvars[host].wireguard_as_spoke | default(false)) != true) and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (wireguard_endpoint is defined and wireguard_endpoint != "")) %}
+{%   if host != inventory_hostname
+         and ((wireguard_as_spoke | default(false)) != true or (hostvars[host].wireguard_as_spoke | default(false)) != true)
+         and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (wireguard_endpoint is defined and wireguard_endpoint != ""))
+         and (wireguard_include_peers is not defined or host in wireguard_include_peers)
+%}
 
 [Peer]
 # Name = {{ host }}
@@ -104,6 +108,7 @@ Endpoint = {{host}}:{{wireguard_port}}
 
 # Peers not managed by Ansible from "wireguard_unmanaged_peers" variable
 {% for peer in wireguard_unmanaged_peers.keys() %}
+{%   if wireguard_include_peers is not defined or peer in wireguard_include_peers %}
 [Peer]
 # Name = {{ peer }}
 PublicKey = {{ wireguard_unmanaged_peers[peer].public_key }}
@@ -119,5 +124,6 @@ Endpoint = {{ wireguard_unmanaged_peers[peer].endpoint }}
 {%     if wireguard_unmanaged_peers[peer].persistent_keepalive is defined %}
 PersistentKeepalive = {{ wireguard_unmanaged_peers[peer].persistent_keepalive }}
 {%     endif %}
+{%    endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
This allows explicitly setting which peers a node can connect to. If the variable is not present, then all peers are included.

Fixes #195