### PR TITLE
Ensure Ansible control node has netaddr package to avoid config generating fail

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,13 @@
 
 - name: Gather instance facts
   ansible.builtin.setup:
-
+  
+- name: Ensure Ansible control node has netaddr package
+  delegate_to: localhost
+  ansible.builtin.pip:
+    name: netaddr
+    state: present
+    
 - name: Include tasks depending on OS
   ansible.builtin.include_tasks:
     file: "{{ item }}"


### PR DESCRIPTION
logs when the problem occurs.

```
The full traceback is:
Traceback (most recent call last):
  File "/config/.pyenv/versions/3.11.5/lib/python3.11/site-packages/ansible/plugins/action/template.py", line 152, in run
    resultant = templar.do_template(template_data, preserve_trailing_newlines=True, escape_backslashes=False, overrides=overrides)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/.pyenv/versions/3.11.5/lib/python3.11/site-packages/ansible/template/__init__.py", line 1001, in do_template
    res = myenv.concat(rf)
          ^^^^^^^^^^^^^^^^
  File "/config/.pyenv/versions/3.11.5/lib/python3.11/site-packages/ansible/template/native_helpers.py", line 83, in ansible_concat
    return ''.join([to_text(v) for v in nodes])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/.pyenv/versions/3.11.5/lib/python3.11/site-packages/ansible/template/native_helpers.py", line 83, in <listcomp>
    return ''.join([to_text(v) for v in nodes])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<template>", line 160, in root
  File "/config/.pyenv/versions/3.11.5/lib/python3.11/site-packages/ansible/template/__init__.py", line 295, in wrapper
    ret = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/config/.pyenv/versions/3.11.5/lib/python3.11/site-packages/ansible_collections/ansible/utils/plugins/plugin_utils/base/ipaddr_utils.py", line 602, in _need_netaddr
    raise AnsibleFilterError(missing_required_lib("netaddr"))
ansible.errors.AnsibleFilterError: Failed to import the required Python library (netaddr) on e4d90f2979d9's Python /config/.pyenv/versions/3.11.5/bin/python3.11. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter
fatal: [idc-hk]: FAILED! => {
    "changed": false,
    "msg": "AnsibleFilterError: Failed to import the required Python library (netaddr) on e4d90f2979d9's Python /config/.pyenv/versions/3.11.5/bin/python3.11. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"
}
```