### PR TITLE
Enable skipping of wg kernel module install

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ wireguard_interface_restart: false
 # Set to "false" if package cache should not be updated (only relevant if
 # the package manager in question supports this option)
 wireguard_update_cache: "true"
+
+# Normally the role installs and activates the wireguard kernel module where
+# appropriate.  In some cases we might not be able load kernel modules, like
+# unprivileged LXC guests.  If you set this to false you have to ensure
+# the wireguard module is available in the kernel!
+wireguard_install_kernel_module: true
 ```
 
 There are also a few Linux distribution specific settings:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,12 @@ wireguard_interface_restart: false
 # the package manager in question supports this option)
 wireguard_update_cache: "true"
 
+# Normally the role installs and activates the wireguard kernel module where
+# appropriate.  In some cases we might not be able load kernel modules, like
+# unprivileged LXC guests.  If you set this to false you have to ensure
+# the wireguard module is available in the kernel!
+wireguard_install_kernel_module: true
+
 #######################################
 # Settings only relevant for:
 # - Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,10 @@
   failed_when: wireguard__register_module_enabled is failure
   tags:
     - wg-install
-  when: not ansible_os_family == 'Darwin'
+    - wg-install-kernel-module
+  when:
+    - not ansible_os_family == 'Darwin'
+    - wireguard_install_kernel_module
 
 - name: Set default for WireGuard interface restart behavior
   ansible.builtin.set_fact:


### PR DESCRIPTION
This PR enables skipping the wg kernel module install based on tag (`wg-install-kernel-module`) or role variable `wireguard_install_kernel_module`.

Fixes #190
