### PR TITLE
Wireguard conf backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+Feature:
+
+- Introduce `wireguard_conf_backup` to keep track of configuration changes. Default to "false"
+
 ## 15.0.0
 
 Breaking:

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ wireguard_conf_group: "{{ 'root' if not ansible_os_family == 'Darwin' else 'whee
 # The default mode of the wg.conf file
 wireguard_conf_mode: 0600
 
+# Whether any change to the wg.conf file should be backup
+wireguard_conf_backup: false
+
 # The default state of the wireguard service
 wireguard_service_enabled: "yes"
 wireguard_service_state: "started"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,9 @@ wireguard_conf_group: "{{ 'root' if not ansible_os_family == 'Darwin' else 'whee
 # The default mode of the wg.conf file
 wireguard_conf_mode: 0600
 
+# Whether any change to the wg.conf file should be backup
+wireguard_conf_backup: false
+
 # The default state of the wireguard service
 wireguard_service_enabled: "yes"
 wireguard_service_state: "started"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -162,6 +162,7 @@
     owner: "{{ wireguard_conf_owner }}"
     group: "{{ wireguard_conf_group }}"
     mode: "{{ wireguard_conf_mode }}"
+    backup: "{{ wireguard_conf_backup }}"
   no_log: '{{ ansible_verbosity < 3 }}'
   tags:
     - wg-config


### PR DESCRIPTION
Setting up tunnels can be error prone and it's nice to have the ability to review a past deployed working configuration when one accidently breaks a tunnel.

By simply leveraging the `backup` directive of the `template` ansible module, one easily let the role user control if that mechanism is useful to them.

Best regards