### PR TITLE
16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,8 @@ Deprecation:
 
 ## 11.0.0
 
-- add support for Rocky Linux 9 (original PR from @vincentDcmps: https://github.com/githubixx/ansible-role-wireguard/pull/163)
-- add support for AlmaLinux 9 (original PR from @trunet: https://github.com/githubixx/ansible-role-wireguard/pull/164)
+- add support for Rocky Linux 9 (original PR from @vincentDcmps: [#163](https://github.com/githubixx/ansible-role-wireguard/pull/163))
+- add support for AlmaLinux 9 (original PR from @trunet: [#164](https://github.com/githubixx/ansible-role-wireguard/pull/164))
 - add `EL9` to `meta/main.yml`
 - require Ansible >= `2.11` as Rocky Linux is only supported with this version or above
 - `ansible-lint`: use `community.general.pacman` module instead of `ansible.builtin.pacman` for Archlinux setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,50 +5,57 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
-Feature:
+## 16.0.0
 
-- Introduce `wireguard_conf_backup` to keep track of configuration changes. Default to "false"
+- **BREAKING**
+  - removed support for Fedora 37/38 (reached end of life)
+
+- **FEATURE**
+  - add support for Fedora 39
+  - introduce `wireguard_conf_backup` variable to keep track of configuration changes. Default to `false`. (contribution by @shk3bq4d)
+  - introduce `wireguard_install_kernel_module`. Allows to skip loading the `wireguard` kernel module. Default to `true` (which was the previous behavior). (contribution by @gregorydlogan)
+
+- **Molecule**
+  - use different IP addresses
+  - use `generic` Vagrant boxes for Rocky Linux
+  - use `alvistack` Vagrant boxes for Ubuntu
+  - use official Rocky Linux 9 Vagrant box
+  - use official AlmaLinux Vagrant boxes
+  - move `memory` and `cpus` parameter to Vagrant boxes
 
 ## 15.0.0
 
-Breaking:
+- **BREAKING**
+  - removed support for Ubuntu 18.04 (reached end of life)
+  - removed support for Fedora 36 (reached end of life)
 
-- removed support for Ubuntu 18.04 (reached end of life)
-- removed support for Fedora 36 (reached end of life)
+- **FEATURE**
+  - add support for Fedora 37
+  - add support for Fedora 38
+  - add support for openSUSE 15.5
+  - add support for Debian 12
+  - prefix host name comment with `Name =` for [wg-info](https://github.com/asdil12/wg-info) in WireGuard interface configuration (contribution by @tarag)
 
-Feature:
+- **MOLECULE**
+  - rename `kvm` scenario to `default`
+  - rename `kvm-single-server` scenario to `single-server`
+  - upgrade OS and reboot in prepare before converge for Almalinux
 
-- add support for Fedora 37
-- add support for Fedora 38
-- add support for openSUSE 15.5
-- add support for Debian 12
-- prefix host name comment with `Name =` for [wg-info](https://github.com/asdil12/wg-info) in WireGuard interface configuration (contribution by @tarag)
-
-Molecule:
-
-- rename `kvm` scenario to `default`
-- rename `kvm-single-server` scenario to `single-server`
-- upgrade OS and reboot in prepare before converge for Almalinux
-
-Other:
-
-- fix `ansible-lint` issues
+- **OTHER**
+  - fix `ansible-lint` issues
 
 ## 14.0.0
 
-Breaking:
+- **BREAKING**
+  - CentOS 7: Introduce `wireguard_centos7_kernel_plus_reboot` and `wireguard_centos7_standard_reboot` variables. Both are set to "true" by default. This will cause the host to be rebooted in case the "wireguard" kernel module was installed the very first time. If `wireguard_centos7_installation_method: "kernel-plus"` is set and the host wasn't booted with a `kernel-plus` kernel already you most probably need to reboot. For the `standard` kernel this might not be needed.
+  - CentOS 7: Add reboot to the standard mode to make sure the WireGuard kernel module is available (contribution by @mofelee)
+  - Introduce `wireguard_update_cache` variable to control if package manager caches should be updated before the installation (contribution by @sebix). Before this release the package manager cache wasn't updated for AlmaLinux 9, Archlinux, Fedora and openSUSE. With `wireguard_update_cache` set to `true` by default those OSes are now also update the package manager cache. If you don't want that set `wireguard_update_cache` to `false` for the host in question.
 
-- CentOS 7: Introduce `wireguard_centos7_kernel_plus_reboot` and `wireguard_centos7_standard_reboot` variables. Both are set to "true" by default. This will cause the host to be rebooted in case the "wireguard" kernel module was installed the very first time. If `wireguard_centos7_installation_method: "kernel-plus"` is set and the host wasn't booted with a `kernel-plus` kernel already you most probably need to reboot. For the `standard` kernel this might not be needed.
-- CentOS 7: Add reboot to the standard mode to make sure the WireGuard kernel module is available (contribution by @mofelee)
-- Introduce `wireguard_update_cache` variable to control if package manager caches should be updated before the installation (contribution by @sebix). Before this release the package manager cache wasn't updated for AlmaLinux 9, Archlinux, Fedora and openSUSE. With `wireguard_update_cache` set to `true` by default those OSes are now also update the package manager cache. If you don't want that set `wireguard_update_cache` to `false` for the host in question.
+- **FEATURE**
+  - add support for Oracle Linux 9 (contribution by @cola-zero)
 
-Feature:
-
-- add support for Oracle Linux 9 (contribution by @cola-zero)
-
-Deprecation:
-
-- variable `wireguard_ubuntu_update_cache` is deprecated
+- **DEPRECATION**
+  - variable `wireguard_ubuntu_update_cache` is deprecated
 
 ## 13.0.1
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ This role should work with:
 - Archlinux
 - Debian 11 (Bullseye)
 - Debian 12 (Bookworm)
-- Fedora 37
-- Fedora 38
+- Fedora 39
 - CentOS 7
 - AlmaLinux 8
 - AlmaLinux 9

--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ Copyright (C) 2019 fbourqui
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-ansible-role-wireguard
-======================
+# ansible-role-wireguard
 
 This Ansible role is used in my blog series [Kubernetes the not so hard way with Ansible](https://www.tauceti.blog/post/kubernetes-the-not-so-hard-way-with-ansible-wireguard/) but can be used standalone of course. I use WireGuard and this Ansible role to setup a fully meshed VPN between all nodes of my little Kubernetes cluster.
 
 In general WireGuard is a network tunnel (VPN) for IPv4 and IPv6 that uses UDP. If you need more information about [WireGuard](https://www.wireguard.io/) you can find a good introduction here: [Installing WireGuard, the Modern VPN](https://research.kudelskisecurity.com/2017/06/07/installing-wireguard-the-modern-vpn/).
 
-Linux
------
+## Linux
 
 This role should work with:
 
@@ -31,14 +29,13 @@ This role should work with:
 - openSUSE Leap 15.5
 - Oracle Linux 9
 
-Best effort:
+## Best effort
 
 - elementary OS 6
 
 Molecule tests are [available](https://github.com/githubixx/ansible-role-wireguard#testing) (see further down below). It should also work with `Raspbian Buster` but for this one there is no test available. MacOS (see below) should also work partitially but is only best effort.
 
-MacOS
------
+## MacOS
 
 While this playbook configures, enables and starts a `systemd` service on Linux in a such a way that no additional action is needed, on MacOS it installs the required packages and it just generates the correct `wg0.conf` file that is then placed in the specified `wireguard_remote_directory` (`/opt/local/etc/wireguard` by default). In order to run the VPN, then, you need to:
 
@@ -54,71 +51,64 @@ sudo wg-quick down wg0
 
 or you can install the [official app](https://apps.apple.com/it/app/wireguard/id1451685025?l=en&mt=12) and import the `wg0.conf` file.
 
-Versions
---------
+## Versions
 
 I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too.
 
-Requirements
-------------
+## Requirements
 
 By default port `51820` (protocol UDP) should be accessible from the outside. But you can adjust the port by changing the variable `wireguard_port`. Also IP forwarding needs to be enabled e.g. via `echo 1 > /proc/sys/net/ipv4/ip_forward`. I decided not to implement this task in this Ansible role. IMHO that should be handled elsewhere.
 You can use my [ansible-role-harden-linux](https://github.com/githubixx/ansible-role-harden-linux) e.g. Besides changing sysctl entries (which you need to enable IP forwarding) it also manages firewall settings among other things.
 Nevertheless the `PreUp`, `PreDown`, `PostUp` and `PostDown` hooks may be a good place to do some network related stuff before a WireGuard interface comes up or goes down.
 
-Changelog
----------
+## Changelog
 
 **Change history:**
 
 See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob/master/CHANGELOG.md)
 
-**Changes in the last two versions:**
+**Recent changes:**
 
-15.0.0
+## 16.0.0
 
-Breaking:
+- **BREAKING**
+  - removed support for Fedora 37/38 (reached end of life)
 
-- removed support for Ubuntu 18.04 (reached end of life)
-- removed support for Fedora 36 (reached end of life)
+- **FEATURE**
+  - add support for Fedora 39
+  - introduce `wireguard_conf_backup` variable to keep track of configuration changes. Default to `false`. (contribution by @shk3bq4d)
+  - introduce `wireguard_install_kernel_module`. Allows to skip loading the `wireguard` kernel module. Default to `true` (which was the previous behavior). (contribution by @gregorydlogan)
 
-Feature:
+- **Molecule**
+  - use different IP addresses
+  - use `generic` Vagrant boxes for Rocky Linux
+  - use `alvistack` Vagrant boxes for Ubuntu
+  - use official Rocky Linux 9 Vagrant box
+  - use official AlmaLinux Vagrant boxes
+  - move `memory` and `cpus` parameter to Vagrant boxes
 
-- add support for Fedora 37
-- add support for Fedora 38
-- add support for openSUSE 15.5
-- add support for Debian 12
-- prefix host name comment with `Name =` for [wg-info](https://github.com/asdil12/wg-info) in WireGuard interface configuration (contribution by @tarag)
+## 15.0.0
 
-Molecule:
+- **BREAKING**
+  - removed support for Ubuntu 18.04 (reached end of life)
+  - removed support for Fedora 36 (reached end of life)
 
-- rename `kvm` scenario to `default`
-- rename `kvm-single-server` scenario to `single-server`
-- upgrade OS and reboot in prepare before converge for Almalinux
+- **FEATURE**
+  - add support for Fedora 37
+  - add support for Fedora 38
+  - add support for openSUSE 15.5
+  - add support for Debian 12
+  - prefix host name comment with `Name =` for [wg-info](https://github.com/asdil12/wg-info) in WireGuard interface configuration (contribution by @tarag)
 
-Other:
+- **MOLECULE**
+  - rename `kvm` scenario to `default`
+  - rename `kvm-single-server` scenario to `single-server`
+  - upgrade OS and reboot in prepare before converge for Almalinux
 
-- fix `ansible-lint` issues
+- **OTHER**
+  - fix `ansible-lint` issues
 
-14.0.0
-
-Breaking:
-
-- CentOS 7: Introduce `wireguard_centos7_kernel_plus_reboot` and `wireguard_centos7_standard_reboot` variables. Both are set to "true" by default. This will cause the host to be rebooted in case the "wireguard" kernel module was installed the very fir
-st time. If `wireguard_centos7_installation_method: "kernel-plus"` is set and the host wasn't booted with a `kernel-plus` kernel already you most probably need to reboot. For the `standard` kernel this might not be needed.
-- CentOS 7: Add reboot to the standard mode to make sure the WireGuard kernel module is available (contribution by @mofelee)
-- Introduce `wireguard_update_cache` variable to control if package manager caches should be updated before the installation (contribution by @sebix). Before this release the package manager cache wasn't updated for AlmaLinux 9, Archlinux, Fedora and openSUSE. With `wireguard_update_cache` set to `true` by default those OSes are now also update the package manager cache. If you don't want that set `wireguard_update_cache` to `false` for the host in question.
-
-Feature:
-
-- add support for Oracle Linux 9 (contribution by @cola-zero)
-
-Deprecation:
-
-- variable `wireguard_ubuntu_update_cache` is deprecated
-
-Installation
-------------
+## Installation
 
 - Directly download from Github (change into Ansible role directory before cloning):
 `git clone https://github.com/githubixx/ansible-role-wireguard.git githubixx.ansible_role_wireguard`
@@ -134,11 +124,10 @@ Installation
 roles:
   - name: githubixx.ansible_role_wireguard
     src: https://github.com/githubixx/ansible-role-wireguard.git
-    version: 15.0.0
+    version: 16.0.0
 ```
 
-Role Variables
---------------
+## Role Variables
 
 These variables can be changed in `group_vars/` e.g.:
 
@@ -522,8 +511,7 @@ Endpoint = server.at.home.p.domain.tld:51820
 
 The other WireGuard config files (`wg0.conf` by default) looks similar but of course `[Interface]` includes the config of that specific host and the `[Peer]` entries lists the config of the other hosts.
 
-Example Playbooks
------------------
+## Example Playbooks
 
 ```yaml
 - hosts: vpn
@@ -539,8 +527,7 @@ Example Playbooks
       tags: role-wireguard
 ```
 
-Example inventory using two different WireGuard interfaces on host "multi"
---------------------------------------------------------------------------
+## Example inventory using two different WireGuard interfaces on host "multi"
 
 This is a complex example using yaml inventory format:
 
@@ -599,8 +586,7 @@ Sample playbooks for example above:
     - githubixx.ansible_role_wireguard
 ```
 
-Testing
--------
+## Testing
 
 This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-wireguard/tree/master/molecule/default).
 
@@ -628,12 +614,10 @@ There is also a small [Molecule setup](https://github.com/githubixx/ansible-role
 molecule converge -s single-server
 ```
 
-License
--------
+## License
 
 [GNU General Public License v3.0 or later](https://spdx.org/licenses/GPL-3.0-or-later.html)
 
-Author Information
-------------------
+## Author Information
 
 [http://www.tauceti.blog](http://www.tauceti.blog)

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,20 +25,8 @@ platforms:
     groups:
       - vpn
       - ubuntu
-  - name: test-wg-fedora37
-    box: generic/fedora37
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.20
-    groups:
-      - vpn
-      - fedora
-  - name: test-wg-fedora38
-    box: generic/fedora38
+  - name: test-wg-fedora39
+    box: generic/fedora39
     memory: 1536
     cpus: 2
     interfaces:
@@ -235,13 +223,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.10"
-      test-wg-fedora37:
-        wireguard_address: "10.10.10.20/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.20"
-        wireguard_interface_restart: true
-      test-wg-fedora38:
+      test-wg-fedora39:
         wireguard_address: "10.10.10.30/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,14 +14,14 @@ driver:
 
 platforms:
   - name: test-wg-ubuntu2004
-    box: ubuntu/focal64
+    box: alvistack/ubuntu-20.04
     memory: 1536
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
     groups:
       - vpn
       - ubuntu
@@ -33,7 +33,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.30
+        ip: 172.16.10.20
     groups:
       - vpn
       - fedora
@@ -45,7 +45,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.50
+        ip: 172.16.10.30
     groups:
       - vpn
       - el7
@@ -57,7 +57,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.60
+        ip: 172.16.10.40
     groups:
       - vpn
       - archlinux
@@ -69,7 +69,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.70
+        ip: 172.16.10.50
     groups:
       - vpn
       - debian
@@ -81,19 +81,19 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.110
+        ip: 172.16.10.60
     groups:
       - vpn
       - debian
   - name: test-wg-rocky8
-    box: rockylinux/8
+    box: generic/rocky8
     memory: 1536
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.80
+        ip: 172.16.10.70
     groups:
       - vpn
       - el8
@@ -105,7 +105,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.90
+        ip: 172.16.10.80
     groups:
       - vpn
       - el8
@@ -118,32 +118,32 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.100
+        ip: 172.16.10.90
     groups:
       - vpn
       - el7
   - name: test-wg-rocky8-dkms
-    box: rockylinux/8
+    box: generic/rocky8
     memory: 1536
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.130
+        ip: 172.16.10.100
     groups:
       - vpn
       - el8
       - el8dkms
   - name: test-wg-ubuntu2204
-    box: ubuntu/jammy64
+    box: alvistack/ubuntu-22.04
     memory: 1536
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.140
+        ip: 172.16.10.110
     groups:
       - vpn
       - ubuntu
@@ -155,7 +155,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.150
+        ip: 172.16.10.120
     groups:
       - vpn
       - opensuse
@@ -167,7 +167,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.190
+        ip: 172.16.10.130
     groups:
       - vpn
       - opensuse
@@ -179,7 +179,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.160
+        ip: 172.16.10.140
     groups:
       - vpn
       - el9
@@ -191,7 +191,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.170
+        ip: 172.16.10.150
     groups:
       - vpn
       - el9
@@ -203,7 +203,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.180
+        ip: 172.16.10.160
     groups:
       - vpn
       - el9
@@ -222,89 +222,89 @@ provisioner:
         wireguard_address: "10.10.10.10/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.10"
+        wireguard_endpoint: "172.16.10.10"
       test-wg-fedora39:
+        wireguard_address: "10.10.10.20/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.20"
+        wireguard_interface_restart: true
+      test-wg-centos7:
         wireguard_address: "10.10.10.30/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.30"
+        wireguard_endpoint: "172.16.10.30"
         wireguard_interface_restart: true
-      test-wg-centos7:
+      test-wg-arch:
+        wireguard_address: "10.10.10.40/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.40"
+        ansible_python_interpreter: "/usr/bin/python"
+      test-wg-debian11:
         wireguard_address: "10.10.10.50/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.50"
-        wireguard_interface_restart: true
-      test-wg-arch:
+        wireguard_endpoint: "172.16.10.50"
+        ansible_python_interpreter: "/usr/bin/python3"
+      test-wg-debian12:
         wireguard_address: "10.10.10.60/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.60"
-        ansible_python_interpreter: "/usr/bin/python"
-      test-wg-debian11:
+        wireguard_endpoint: "172.16.10.60"
+        ansible_python_interpreter: "/usr/bin/python3"
+      test-wg-rocky8:
         wireguard_address: "10.10.10.70/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.70"
-        ansible_python_interpreter: "/usr/bin/python3"
-      test-wg-debian12:
-        wireguard_address: "10.10.10.110/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.110"
-        ansible_python_interpreter: "/usr/bin/python3"
-      test-wg-rocky8:
+        wireguard_endpoint: "172.16.10.70"
+      test-wg-alma8:
         wireguard_address: "10.10.10.80/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.80"
-      test-wg-alma8:
-        wireguard_address: "10.10.10.90/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.90"
+        wireguard_endpoint: "172.16.10.80"
       test-wg-centos7-kernel-plus:
-        wireguard_address: "10.10.10.100/24"
+        wireguard_address: "10.10.10.90/24"
         wireguard_port: 51821
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.100"
+        wireguard_endpoint: "172.16.10.90"
         wireguard_centos7_installation_method: "kernel-plus"
       test-wg-rocky8-dkms:
+        wireguard_address: "10.10.10.100/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.100"
+        wireguard_rockylinux8_installation_method: "dkms"
+      test-wg-ubuntu2204:
+        wireguard_address: "10.10.10.110/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.110"
+      test-wg-opensuse-leap-15-4:
+        wireguard_address: "10.10.10.120/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.120"
+      test-wg-opensuse-leap-15-5:
         wireguard_address: "10.10.10.130/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.130"
-        wireguard_rockylinux8_installation_method: "dkms"
-      test-wg-ubuntu2204:
+        wireguard_endpoint: "172.16.10.130"
+      test-wg-rocky9:
         wireguard_address: "10.10.10.140/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.140"
-      test-wg-opensuse-leap-15-4:
+        wireguard_endpoint: "172.16.10.140"
+      test-wg-alma9:
         wireguard_address: "10.10.10.150/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.150"
-      test-wg-opensuse-leap-15-5:
-        wireguard_address: "10.10.10.190/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.190"
-      test-wg-rocky9:
+        wireguard_endpoint: "172.16.10.150"
+      test-wg-oracle9:
         wireguard_address: "10.10.10.160/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.160"
-      test-wg-alma9:
-        wireguard_address: "10.10.10.170/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.170"
-      test-wg-oracle9:
-        wireguard_address: "10.10.10.180/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "192.168.10.180"
+        wireguard_endpoint: "172.16.10.160"
 
 scenario:
   name: default

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ driver:
 
 platforms:
   - name: test-wg-ubuntu2004
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-20.04
     memory: 1536
     cpus: 2
     interfaces:
@@ -148,7 +148,7 @@ platforms:
       - el8
       - el8dkms
   - name: test-wg-ubuntu2204
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 1536
     cpus: 2
     interfaces:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ driver:
 
 platforms:
   - name: test-wg-ubuntu2004
-    box: alvistack/ubuntu-20.04
+    box: ubuntu/focal64
     memory: 1536
     cpus: 2
     interfaces:
@@ -136,7 +136,7 @@ platforms:
       - el8
       - el8dkms
   - name: test-wg-ubuntu2204
-    box: alvistack/ubuntu-22.04
+    box: ubuntu/jammy64
     memory: 1536
     cpus: 2
     interfaces:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -98,7 +98,7 @@ platforms:
       - vpn
       - el8
   - name: test-wg-alma8
-    box: generic/alma8
+    box: almalinux/8
     memory: 1536
     cpus: 2
     interfaces:
@@ -184,7 +184,7 @@ platforms:
       - vpn
       - el9
   - name: test-wg-alma9
-    box: generic/alma9
+    box: almalinux/9
     memory: 1536
     cpus: 2
     interfaces:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -252,6 +252,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.60"
+        wireguard_conf_backup: true
         ansible_python_interpreter: "/usr/bin/python3"
       test-wg-rocky8:
         wireguard_address: "10.10.10.70/24"
@@ -280,6 +281,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.110"
+        wireguard_conf_backup: true
       test-wg-opensuse-leap-15-4:
         wireguard_address: "10.10.10.120/24"
         wireguard_port: 51820

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -86,7 +86,7 @@ platforms:
       - vpn
       - debian
   - name: test-wg-rocky8
-    box: generic/rocky8
+    box: rockylinux/8
     memory: 1536
     cpus: 2
     interfaces:
@@ -123,7 +123,7 @@ platforms:
       - vpn
       - el7
   - name: test-wg-rocky8-dkms
-    box: generic/rocky8
+    box: rockylinux/8
     memory: 1536
     cpus: 2
     interfaces:
@@ -172,7 +172,7 @@ platforms:
       - vpn
       - opensuse
   - name: test-wg-rocky9
-    box: generic/rocky9
+    box: rockylinux/9
     memory: 1536
     cpus: 2
     interfaces:

--- a/molecule/single-server/molecule.yml
+++ b/molecule/single-server/molecule.yml
@@ -25,7 +25,7 @@ platforms:
       - vpn
       - ubuntu
   - name: test-wg-debian12
-    box: alvistack/debian-12
+    box: generic/debian12
     memory: 1536
     cpus: 2
     interfaces:

--- a/molecule/single-server/molecule.yml
+++ b/molecule/single-server/molecule.yml
@@ -21,7 +21,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
     groups:
       - vpn
       - ubuntu
@@ -31,7 +31,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.30
+        ip: 172.16.10.20
     groups:
       - vpn
       - debian
@@ -41,7 +41,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.40
+        ip: 172.16.10.30
     groups:
       - vpn
       - ubuntu
@@ -62,12 +62,12 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.10"
       test-wg-debian11:
-        wireguard_address: "10.10.10.30/24"
+        wireguard_address: "10.10.10.20/24"
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: ""
         ansible_python_interpreter: "/usr/bin/python3"
       test-wg-ubuntu2204:
-        wireguard_address: "10.10.10.40/24"
+        wireguard_address: "10.10.10.30/24"
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: ""
 

--- a/molecule/single-server/molecule.yml
+++ b/molecule/single-server/molecule.yml
@@ -10,13 +10,12 @@ driver:
   provider:
     name: libvirt
     type: libvirt
-    options:
-      memory: 192
-      cpus: 2
 
 platforms:
   - name: test-wg-ubuntu2004
     box: alvistack/ubuntu-20.04
+    memory: 1536
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -25,8 +24,10 @@ platforms:
     groups:
       - vpn
       - ubuntu
-  - name: test-wg-debian11
+  - name: test-wg-debian12
     box: alvistack/debian-12
+    memory: 1536
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -37,6 +38,8 @@ platforms:
       - debian
   - name: test-wg-ubuntu2204
     box: alvistack/ubuntu-22.04
+    memory: 1536
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -61,7 +64,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "192.168.10.10"
-      test-wg-debian11:
+      test-wg-debian12:
         wireguard_address: "10.10.10.20/24"
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: ""

--- a/molecule/single-server/molecule.yml
+++ b/molecule/single-server/molecule.yml
@@ -16,7 +16,7 @@ driver:
 
 platforms:
   - name: test-wg-ubuntu2004
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-20.04
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -26,7 +26,7 @@ platforms:
       - vpn
       - ubuntu
   - name: test-wg-debian11
-    box: generic/debian11
+    box: alvistack/debian-12
     interfaces:
       - auto_config: true
         network_name: private_network


### PR DESCRIPTION
- **BREAKING**
  - removed support for Fedora 37/38 (reached end of life)

- **FEATURE**
  - add support for Fedora 39
  - introduce `wireguard_conf_backup` variable to keep track of configuration changes. Default to `false`. (contribution by @shk3bq4d)
  - introduce `wireguard_install_kernel_module`. Allows to skip loading the `wireguard` kernel module. Default to `true` (which was the previous behavior). (contribution by @gregorydlogan)

- **Molecule**
  - use different IP addresses
  - use `generic` Vagrant boxes for Rocky Linux
  - use `alvistack` Vagrant boxes for Ubuntu
  - use official Rocky Linux 9 Vagrant box
  - use official AlmaLinux Vagrant boxes
  - move `memory` and `cpus` parameter to Vagrant boxes