### PR TITLE
Update setup-fedora.yml

### DIFF
--- a/tasks/setup-fedora.yml
+++ b/tasks/setup-fedora.yml
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Fedora) Install WireGuard packages
+  when:
+    - ansible_pkg_mgr != "atomic_container"
   ansible.builtin.yum:
     name:
       - "wireguard-tools"


### PR DESCRIPTION
Fedora CoreOS has full support for WireGuard out of the box and does not have yum.

This change makes it possible to setup wg on FedoraOS.