### PR TITLE
17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2018-2023 Robert Wimmer
+Copyright (C) 2018-2024 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
@@ -8,11 +8,18 @@ SPDX-License-Identifier: GPL-3.0-or-later
 ## 17.0.0
 
 - **BREAKING**
-  - removed support for openSUSE 15.4 (reached end of life)
+  - removed support for `openSUSE 15.4` (reached end of life)
 
 - **FEATURE**
-  - add support for Ubuntu 24.04
+  - add support for `Ubuntu 24.04`
+  - add support for `openSUSE 15.6`
 
+- **MOLECULE**
+  - remove outdated `Proxmox` code
+  - replace Vagrant box `rockylinux/9` with `bento/rockylinux-9`
+  - use `ansible.builtin.package` for AlmaLinux
+  - remove `AlmaLinux 8`, `Rocky Linux 8` and `CentOS 7` (outdated Python makes it hard to test with Ansible)
+ 
 ## 16.0.2
 
 - **OTHER**
@@ -34,7 +41,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   - introduce `wireguard_conf_backup` variable to keep track of configuration changes. Default to `false`. (contribution by @shk3bq4d)
   - introduce `wireguard_install_kernel_module`. Allows to skip loading the `wireguard` kernel module. Default to `true` (which was the previous behavior). (contribution by @gregorydlogan)
 
-- **Molecule**
+- **MOLECULE**
   - use different IP addresses
   - use `generic` Vagrant boxes for Rocky Linux
   - use `alvistack` Vagrant boxes for Ubuntu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 17.0.0
+
+- **BREAKING**
+  - removed support for openSUSE 15.4 (reached end of life)
+
 ## 16.0.2
 
 - **OTHER**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - **BREAKING**
   - removed support for openSUSE 15.4 (reached end of life)
 
+- **FEATURE**
+  - add support for Ubuntu 24.04
+
 ## 16.0.2
 
 - **OTHER**

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 
 **Recent changes:**
 
+## 17.0.0
+
+- **BREAKING**
+  - removed support for openSUSE 15.4 (reached end of life)
+
+- **FEATURE**
+  - add support for Ubuntu 24.04
+
 ## 16.0.2
 
 - **OTHER**
@@ -98,27 +106,6 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
   - use official AlmaLinux Vagrant boxes
   - move `memory` and `cpus` parameter to Vagrant boxes
 
-## 15.0.0
-
-- **BREAKING**
-  - removed support for Ubuntu 18.04 (reached end of life)
-  - removed support for Fedora 36 (reached end of life)
-
-- **FEATURE**
-  - add support for Fedora 37
-  - add support for Fedora 38
-  - add support for openSUSE 15.5
-  - add support for Debian 12
-  - prefix host name comment with `Name =` for [wg-info](https://github.com/asdil12/wg-info) in WireGuard interface configuration (contribution by @tarag)
-
-- **MOLECULE**
-  - rename `kvm` scenario to `default`
-  - rename `kvm-single-server` scenario to `single-server`
-  - upgrade OS and reboot in prepare before converge for Almalinux
-
-- **OTHER**
-  - fix `ansible-lint` issues
-
 ## Installation
 
 - Directly download from Github (change into Ansible role directory before cloning):
@@ -135,7 +122,7 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 roles:
   - name: githubixx.ansible_role_wireguard
     src: https://github.com/githubixx/ansible-role-wireguard.git
-    version: 16.0.0
+    version: 17.0.0
 ```
 
 ## Role Variables

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ This role should work with:
 - Debian 11 (Bullseye)
 - Debian 12 (Bookworm)
 - Fedora 39
-- AlmaLinux 8
 - AlmaLinux 9
-- Rocky Linux 8
 - Rocky Linux 9
 - openSUSE Leap 15.5
 - Oracle Linux 9
 
 ## Best effort
 
-- CentOS 7 (it's end of life since end June 2024)
+- AlmaLinux 8
+- Rocky Linux 8
 - elementary OS 6
+- CentOS 7 (end of life since end June 2024)
 
 Molecule tests are [available](https://github.com/githubixx/ansible-role-wireguard#testing) (see further down below). It should also work with `Raspbian Buster` but for this one there is no test available. MacOS (see below) should also work partitially but is only best effort.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This role should work with:
 - Debian 11 (Bullseye)
 - Debian 12 (Bookworm)
 - Fedora 39
-- CentOS 7
 - AlmaLinux 8
 - AlmaLinux 9
 - Rocky Linux 8
@@ -31,6 +30,7 @@ This role should work with:
 
 ## Best effort
 
+- CentOS 7 (it's end of life since end June 2024)
 - elementary OS 6
 
 Molecule tests are [available](https://github.com/githubixx/ansible-role-wireguard#testing) (see further down below). It should also work with `Raspbian Buster` but for this one there is no test available. MacOS (see below) should also work partitially but is only best effort.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This role should work with:
 - AlmaLinux 9
 - Rocky Linux 9
 - openSUSE Leap 15.5
+- openSUSE Leap 15.6
 - Oracle Linux 9
 
 ## Best effort

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ This role should work with:
 - AlmaLinux 9
 - Rocky Linux 8
 - Rocky Linux 9
-- openSUSE Leap 15.4
 - openSUSE Leap 15.5
 - Oracle Linux 9
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This role should work with:
 - elementary OS 6
 - CentOS 7 (end of life since end June 2024)
 
-Molecule tests are [available](https://github.com/githubixx/ansible-role-wireguard#testing) (see further down below). It should also work with `Raspbian Buster` but for this one there is no test available. MacOS (see below) should also work partitially but is only best effort.
+Molecule tests are [available](https://github.com/githubixx/ansible-role-wireguard#testing) (see further down below). It should also work with `Raspbian Buster` but for this one there is no test available. MacOS (see below) should also work partially but is only best effort.
 
 ## MacOS
 
@@ -113,7 +113,7 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 `git clone https://github.com/githubixx/ansible-role-wireguard.git githubixx.ansible_role_wireguard`
 
 - Via `ansible-galaxy` command and download directly from Ansible Galaxy:
-`ansible-galaxy install role githubixx.ansible_role_wireguard`
+`ansible-galaxy role install githubixx.ansible_role_wireguard`
 
 - Create a `requirements.yml` file with the following content (this will download the role from Github) and install with
 `ansible-galaxy role install -r requirements.yml`:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This role should work with:
 
 - Ubuntu 20.04 (Focal Fossa)
 - Ubuntu 22.04 (Jammy Jellyfish)
+- Ubuntu 24.04 (Noble Numbat)
 - Archlinux
 - Debian 11 (Bullseye)
 - Debian 12 (Bookworm)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,6 @@ galaxy_info:
         - "39"
     - name: opensuse
       versions:
-        - "15.4"
         - "15.5"
   galaxy_tags:
     - networking

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - "focal"
         - "jammy"
+        - "noble"
     - name: Debian
       versions:
         - "bullseye"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -147,18 +147,6 @@ platforms:
     groups:
       - vpn
       - ubuntu
-  - name: test-wg-opensuse-leap-15-4
-    box: opensuse/Leap-15.4.x86_64
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.120
-    groups:
-      - vpn
-      - opensuse
   - name: test-wg-opensuse-leap-15-5
     box: opensuse/Leap-15.5.x86_64
     memory: 1536
@@ -282,11 +270,6 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.110"
         wireguard_conf_backup: true
-      test-wg-opensuse-leap-15-4:
-        wireguard_address: "10.10.10.120/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.120"
       test-wg-opensuse-leap-15-5:
         wireguard_address: "10.10.10.130/24"
         wireguard_port: 51820

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -147,6 +147,18 @@ platforms:
     groups:
       - vpn
       - ubuntu
+  - name: test-wg-ubuntu2404
+    box: alvistack/ubuntu-24.04
+    memory: 1536
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.120
+    groups:
+      - vpn
+      - ubuntu
   - name: test-wg-opensuse-leap-15-5
     box: opensuse/Leap-15.5.x86_64
     memory: 1536
@@ -270,6 +282,11 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.110"
         wireguard_conf_backup: true
+      test-wg-ubuntu2404:
+        wireguard_address: "10.10.10.120/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.120"
       test-wg-opensuse-leap-15-5:
         wireguard_address: "10.10.10.130/24"
         wireguard_port: 51820

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,18 +37,6 @@ platforms:
     groups:
       - vpn
       - fedora
-  - name: test-wg-centos7
-    box: generic/centos7
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.30
-    groups:
-      - vpn
-      - el7
   - name: test-wg-arch
     box: archlinux/archlinux
     memory: 1536
@@ -97,31 +85,20 @@ platforms:
     groups:
       - vpn
       - el8
-  - name: test-wg-alma8
-    box: almalinux/8
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.80
-    groups:
-      - vpn
-      - el8
-      - almalinux8
-  - name: test-wg-centos7-kernel-plus
-    box: generic/centos7
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.90
-    groups:
-      - vpn
-      - el7
+      - rocky8
+   - name: test-wg-alma8
+     box: almalinux/8
+     memory: 1536
+     cpus: 2
+     interfaces:
+       - auto_config: true
+         network_name: private_network
+         type: static
+         ip: 172.16.10.80
+     groups:
+       - vpn
+       - el8
+       - almalinux8
   - name: test-wg-rocky8-dkms
     box: generic/rocky8
     memory: 1536
@@ -229,12 +206,6 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.20"
         wireguard_interface_restart: true
-      test-wg-centos7:
-        wireguard_address: "10.10.10.30/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.30"
-        wireguard_interface_restart: true
       test-wg-arch:
         wireguard_address: "10.10.10.40/24"
         wireguard_port: 51820
@@ -259,18 +230,13 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.70"
+        ansible_python_interpreter: "/usr/bin/python3.9"
       test-wg-alma8:
         wireguard_address: "10.10.10.80/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.80"
-        ansible_python_interpreter: "/usr/bin/python3.9"
-      test-wg-centos7-kernel-plus:
-        wireguard_address: "10.10.10.90/24"
-        wireguard_port: 51821
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.90"
-        wireguard_centos7_installation_method: "kernel-plus"
+        ansible_python_interpreter: "/usr/bin/python3.11"
       test-wg-rocky8-dkms:
         wireguard_address: "10.10.10.100/24"
         wireguard_port: 51820
@@ -294,7 +260,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.130"
-        ansible_python_interpreter: "/usr/bin/python3.11"
+        ansible_python_interpreter: "/usr/bin/python3.9"
       test-wg-rocky9:
         wireguard_address: "10.10.10.140/24"
         wireguard_port: 51820

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -73,45 +73,6 @@ platforms:
     groups:
       - vpn
       - debian
-  - name: test-wg-rocky8
-    box: generic/rocky8
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.70
-    groups:
-      - vpn
-      - el8
-      - rocky8
-   - name: test-wg-alma8
-     box: almalinux/8
-     memory: 1536
-     cpus: 2
-     interfaces:
-       - auto_config: true
-         network_name: private_network
-         type: static
-         ip: 172.16.10.80
-     groups:
-       - vpn
-       - el8
-       - almalinux8
-  - name: test-wg-rocky8-dkms
-    box: generic/rocky8
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.100
-    groups:
-      - vpn
-      - el8
-      - el8dkms
   - name: test-wg-ubuntu2204
     box: alvistack/ubuntu-22.04
     memory: 1536
@@ -225,25 +186,6 @@ provisioner:
         wireguard_endpoint: "172.16.10.60"
         wireguard_conf_backup: true
         ansible_python_interpreter: "/usr/bin/python3"
-      test-wg-rocky8:
-        wireguard_address: "10.10.10.70/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.70"
-        ansible_python_interpreter: "/usr/bin/python3.9"
-      test-wg-alma8:
-        wireguard_address: "10.10.10.80/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.80"
-        ansible_python_interpreter: "/usr/bin/python3.11"
-      test-wg-rocky8-dkms:
-        wireguard_address: "10.10.10.100/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.100"
-        wireguard_rockylinux8_installation_method: "dkms"
-        ansible_python_interpreter: "/usr/bin/python3.9"
       test-wg-ubuntu2204:
         wireguard_address: "10.10.10.110/24"
         wireguard_port: 51820

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -172,7 +172,7 @@ platforms:
       - vpn
       - opensuse
   - name: test-wg-rocky9
-    box: rockylinux/9
+    box: bento/rockylinux-9
     memory: 1536
     cpus: 2
     interfaces:
@@ -264,6 +264,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.80"
+        ansible_python_interpreter: "/usr/bin/python3.9"
       test-wg-centos7-kernel-plus:
         wireguard_address: "10.10.10.90/24"
         wireguard_port: 51821
@@ -276,6 +277,7 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.100"
         wireguard_rockylinux8_installation_method: "dkms"
+        ansible_python_interpreter: "/usr/bin/python3.9"
       test-wg-ubuntu2204:
         wireguard_address: "10.10.10.110/24"
         wireguard_port: 51820
@@ -292,6 +294,7 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.130"
+        ansible_python_interpreter: "/usr/bin/python3.11"
       test-wg-rocky9:
         wireguard_address: "10.10.10.140/24"
         wireguard_port: 51820

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -73,6 +73,18 @@ platforms:
     groups:
       - vpn
       - debian
+  - name: test-wg-opensuse-leap-15-6
+    box: opensuse/Leap-15.6.x86_64
+    memory: 1536
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.70
+    groups:
+      - vpn
+      - opensuse
   - name: test-wg-ubuntu2204
     box: alvistack/ubuntu-22.04
     memory: 1536
@@ -186,6 +198,13 @@ provisioner:
         wireguard_endpoint: "172.16.10.60"
         wireguard_conf_backup: true
         ansible_python_interpreter: "/usr/bin/python3"
+      test-wg-opensuse-leap-15-6:
+        wireguard_address: "10.10.10.70/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.70"
+        wireguard_conf_backup: true
+        ansible_python_interpreter: "/usr/bin/python3.9"
       test-wg-ubuntu2204:
         wireguard_address: "10.10.10.110/24"
         wireguard_port: 51820

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -40,17 +40,6 @@
         executable: /bin/bash
       changed_when: false
 
-- name: Prepare Proxmox hosts
-  hosts: proxmox
-  remote_user: vagrant
-  become: true
-  gather_facts: true
-  tasks:
-    - name: (Proxmox) Delete /var/lib/apt/lists/lock
-      ansible.builtin.file:
-        name: /var/lib/apt/lists/lock
-        state: absent
-
 - name: Prepare Ubuntu hosts
   hosts: ubuntu
   remote_user: vagrant

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -6,12 +6,11 @@
   hosts: opensuse
   remote_user: vagrant
   become: true
-  gather_facts: true
+  gather_facts: false
   tasks:
-    - name: Remove backports repositories
+    - name: Install Python 3.9
       ansible.builtin.raw: |
-        zypper rr repo-backports-debug-update
-        zypper rr repo-backports-update
+        zypper install --no-confirm --no-recommends python39
       changed_when: false
       failed_when: false
 
@@ -51,17 +50,31 @@
         update_cache: true
         cache_valid_time: 3600
 
+- name: Prepare Enterprise Linux 8 hosts
+  hosts: rocky8
+  remote_user: vagrant
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Install ELRepo mainline kernel
+      ansible.builtin.raw: |
+        dnf --assumeyes install python39
+      changed_when: false
+      failed_when: false
+
+    - name: Reboot for kernel updates
+      ansible.builtin.reboot:
+
 - name: Prepare Enterprise Linux 8 hosts (DKMS)
   hosts: el8dkms
   remote_user: vagrant
   become: true
-  gather_facts: true
+  gather_facts: false
   tasks:
     - name: Install ELRepo mainline kernel
       ansible.builtin.raw: |
-        rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
-        dnf install -y https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm
-        dnf --enablerepo=elrepo-kernel install -y kernel-ml
+        dnf --assumeyes --enablerepo=elrepo-kernel install kernel-ml
+        dnf --assumeyes install python39
       changed_when: false
       failed_when: false
 
@@ -72,11 +85,12 @@
   hosts: almalinux8
   remote_user: vagrant
   become: true
-  gather_facts: true
+  gather_facts: false
   tasks:
-    - name: Install ELRepo mainline kernel
+    - name: Install Python 3.9
       ansible.builtin.raw: |
-        dnf -y upgrade
+        dnf --assumeyes upgrade
+        dnf --assumeyes install python39
       changed_when: false
       failed_when: false
 

--- a/tasks/setup-almalinux-8.yml
+++ b/tasks/setup-almalinux-8.yml
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (AlmaLinux 8) Install EPEL & ELRepo repository
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name:
       - epel-release
       - elrepo-release
     update_cache: "{{ wireguard_update_cache }}"
 
 - name: (AlmaLinux 8) Ensure WireGuard DKMS package is removed
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name:
       - "wireguard-dkms"
     state: absent
 
 - name: (AlmaLinux 8) Install WireGuard packages
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name:
       - "kmod-wireguard"
       - "wireguard-tools"


### PR DESCRIPTION
- **BREAKING**
  - removed support for `openSUSE 15.4` (reached end of life)

- **FEATURE**
  - add support for `Ubuntu 24.04`
  - add support for `openSUSE 15.6`

- **MOLECULE**
  - remove outdated `Proxmox` code
  - replace Vagrant box `rockylinux/9` with `bento/rockylinux-9`
  - use `ansible.builtin.package` for AlmaLinux
  - remove `AlmaLinux 8`, `Rocky Linux 8` and `CentOS 7` (outdated Python makes it hard to test with Ansible)