### PR TITLE
17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 17.1.0
+
+- **FIXES**
+  - add missing `wg-config` tag ([Issue #211](https://github.com/githubixx/ansible-role-wireguard/issues/211))
+  - hide peers with empty endpoints ([Issue #101](https://github.com/githubixx/ansible-role-wireguard/issues/101))
+
+- **FEATURE**
+  - add support for `Fedora 40`
+  - add [Netplan](https://netplan.io/) support for Ubuntu (contribution by @kbcz1989)
+
+- **OTHER**
+  - update `.yamllint`
+  - fix `ansible-lint` issues
+  - update `.gitignore`
+
 ## 17.0.0
 
 - **BREAKING**

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 
 **Recent changes:**
 
+## 17.1.0
+
+- **FIXES**
+  - add missing `wg-config` tag ([Issue #211](https://github.com/githubixx/ansible-role-wireguard/issues/211))
+  - hide peers with empty endpoints ([Issue #101](https://github.com/githubixx/ansible-role-wireguard/issues/101))
+
+- **FEATURE**
+  - add support for `Fedora 40`
+  - add [Netplan](https://netplan.io/) support for Ubuntu (contribution by @kbcz1989)
+
+- **OTHER**
+  - update `.yamllint`
+  - fix `ansible-lint` issues
+  - update `.gitignore`
+
 ## 17.0.0
 
 - **BREAKING**
@@ -84,35 +99,6 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
   - replace Vagrant box `rockylinux/9` with `bento/rockylinux-9`
   - use `ansible.builtin.package` for AlmaLinux
   - remove `AlmaLinux 8`, `Rocky Linux 8` and `CentOS 7` (outdated Python makes it hard to test with Ansible)
-
-## 16.0.2
-
-- **OTHER**
-  - revert change in `.github/workflows/release.yml`
-
-## 16.0.1
-
-- **OTHER**
-  - update `.github/workflows/release.yml`
-  - update `meta/main.yml`
-
-## 16.0.0
-
-- **BREAKING**
-  - removed support for Fedora 37/38 (reached end of life)
-
-- **FEATURE**
-  - add support for Fedora 39
-  - introduce `wireguard_conf_backup` variable to keep track of configuration changes. Default to `false`. (contribution by @shk3bq4d)
-  - introduce `wireguard_install_kernel_module`. Allows to skip loading the `wireguard` kernel module. Default to `true` (which was the previous behavior). (contribution by @gregorydlogan)
-
-- **Molecule**
-  - use different IP addresses
-  - use `generic` Vagrant boxes for Rocky Linux
-  - use `alvistack` Vagrant boxes for Ubuntu
-  - use official Rocky Linux 9 Vagrant box
-  - use official AlmaLinux Vagrant boxes
-  - move `memory` and `cpus` parameter to Vagrant boxes
 
 ## Installation
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
     - name: opensuse
       versions:
         - "15.5"
+        - "15.6"
   galaxy_tags:
     - networking
     - security

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,7 @@ galaxy_info:
     - name: Fedora
       versions:
         - "39"
+        - "40"
     - name: opensuse
       versions:
         - "15.5"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,6 +37,18 @@ platforms:
     groups:
       - vpn
       - fedora
+  - name: test-wg-fedora40
+    box: alvistack/fedora-40
+    memory: 1536
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.30
+    groups:
+      - vpn
+      - fedora
   - name: test-wg-arch
     box: archlinux/archlinux
     memory: 1536
@@ -178,6 +190,12 @@ provisioner:
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.20"
+        wireguard_interface_restart: true
+      test-wg-fedora40:
+        wireguard_address: "10.10.10.30/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.30"
         wireguard_interface_restart: true
       test-wg-arch:
         wireguard_address: "10.10.10.40/24"

--- a/molecule/netplan/converge.yml
+++ b/molecule/netplan/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2020-2023 Robert Wimmer
+# Copyright (C) 2020-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup WireGuard

--- a/molecule/netplan/molecule.yml
+++ b/molecule/netplan/molecule.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2020-2023 Robert Wimmer
-# Copyright (C) 2020 Pierre Ozoux
+# Copyright (C) 2020-2024 Robert Wimmer
+# Copyright (C) 2020-2024 Pierre Ozoux
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/netplan/verify.yml
+++ b/molecule/netplan/verify.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2023 Robert Wimmer
+# Copyright (C) 2023-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Verify setup


### PR DESCRIPTION
- **FIXES**
  - add missing `wg-config` tag ([Issue #211](https://github.com/githubixx/ansible-role-wireguard/issues/211))
  - hide peers with empty endpoints ([Issue #101](https://github.com/githubixx/ansible-role-wireguard/issues/101))

- **FEATURE**
  - add support for `Fedora 40`
  - add [Netplan](https://netplan.io/) support for Ubuntu (contribution by @kbcz1989)

- **OTHER**
  - update `.yamllint`
  - fix `ansible-lint` issues
  - update `.gitignore`