### PR TITLE
fix: ensure peers are only output when the public key fact is availab…

### DIFF
--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -54,7 +54,7 @@ PostDown = {{ wg_postdown }}
 SaveConfig = {{ wireguard_save_config }}
 {% endif %}
 {% for host in ansible_play_hosts %}
-{%   if host != inventory_hostname and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (wireguard_endpoint is defined and wireguard_endpoint != "")) %}
+{%   if host != inventory_hostname and hostvars[host].wireguard__fact_public_key is defined and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (wireguard_endpoint is defined and wireguard_endpoint != "")) %}
 
 [Peer]
 # Name = {{ host }}


### PR DESCRIPTION
…le for them

In the case wireguard is installed for only a subgroup of all the hosts in the play, the current solution will not work.

This is a quick fix to not create peers if the public key has not been set as a fact for this host.