### PR TITLE
18.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 18.1.0
+
+- **OTHER**
+  - Fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
+
 ## 18.0.0
 
 - **BREAKING**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 ## 18.1.0
 
 - **OTHER**
-  - Fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
+  - fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
+  - replace `ansible_managed` variable with internal `wireguard__ansible_managed` variable. Reason: `DEFAULT_MANAGED_STR` option is deprecated in Ansible 2.19. The `ansible_managed` variable can be set just like any other variable, or a different variable can be used. At the end for now nothing changes for the user of this role as the output string `Ansible managed` will stay the same.
+
+- **MOLECULE**
+  - Molecule: update `netplan` scenario
+  - Molecule: update `single-server` scenario
 
 ## 18.0.0
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,14 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 **Recent changes:**
 
 ## 18.1.0
-  
+
 - **OTHER**
-  - Fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
+  - fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
+  - replace `ansible_managed` variable with internal `wireguard__ansible_managed` variable. Reason: `DEFAULT_MANAGED_STR` option is deprecated in Ansible 2.19. The `ansible_managed` variable can be set just like any other variable, or a different variable can be used. At the end for now nothing changes for the user of this role as the output string `Ansible managed` will stay the same.
+
+- **MOLECULE**
+  - Molecule: update `netplan` scenario
+  - Molecule: update `single-server` scenario
 
 ## 18.0.0
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 
 **Recent changes:**
 
+## 18.1.0
+  
+- **OTHER**
+  - Fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
+
 ## 18.0.0
 
 - **BREAKING**

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ driver:
 
 platforms:
   - name: test-wg-debian13
-    box:  alvistack/debian-13
+    box: alvistack/debian-13
     memory: 1536
     cpus: 2
     interfaces:

--- a/molecule/netplan/molecule.yml
+++ b/molecule/netplan/molecule.yml
@@ -13,8 +13,8 @@ driver:
     type: libvirt
 
 platforms:
-  - name: test-wg-ubuntu2004
-    box: alvistack/ubuntu-20.04
+  - name: test-wg01-ubuntu2404
+    box: alvistack/ubuntu-24.04
     memory: 1536
     cpus: 2
     interfaces:
@@ -25,7 +25,7 @@ platforms:
     groups:
       - vpn
       - ubuntu
-  - name: test-wg-ubuntu2204
+  - name: test-wg02-ubuntu2204
     box: alvistack/ubuntu-22.04
     memory: 1536
     cpus: 2
@@ -37,7 +37,7 @@ platforms:
     groups:
       - vpn
       - ubuntu
-  - name: test-wg-ubuntu2404
+  - name: test-wg03-ubuntu2404
     box: alvistack/ubuntu-24.04
     memory: 1536
     cpus: 2
@@ -60,18 +60,18 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
-      test-wg-ubuntu2004:
+      test-wg01-ubuntu2404:
         wireguard_address: "10.10.10.10/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.10"
-      test-wg-ubuntu2204:
+      test-wg02-ubuntu2204:
         wireguard_address: "10.10.10.20/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.20"
         wireguard_conf_backup: true
-      test-wg-ubuntu2404:
+      test-wg03-ubuntu2404:
         wireguard_address: "10.10.10.30/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"

--- a/molecule/single-server/molecule.yml
+++ b/molecule/single-server/molecule.yml
@@ -12,8 +12,8 @@ driver:
     type: libvirt
 
 platforms:
-  - name: test-wg-ubuntu2004
-    box: alvistack/ubuntu-20.04
+  - name: test-wg-ubuntu2404
+    box: alvistack/ubuntu-24.04
     memory: 1536
     cpus: 2
     interfaces:
@@ -59,7 +59,7 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
-      test-wg-ubuntu2004:
+      test-wg-ubuntu2404:
         wireguard_address: "10.10.10.10/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -162,6 +162,8 @@
   when: not wireguard_ubuntu_use_netplan
 
 - name: Generate WireGuard configuration file
+  vars:
+    wireguard__ansible_managed: "Ansible managed"
   ansible.builtin.template:
     src: "etc/{{ 'wireguard/wg.conf.j2' if not wireguard_ubuntu_use_netplan else 'netplan/wg.yaml.j2' }}"
     dest: "{{ wireguard_remote_directory }}/{{ wireguard_conf_filename }}"

--- a/templates/etc/netplan/wg.yaml.j2
+++ b/templates/etc/netplan/wg.yaml.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+# {{ wireguard__ansible_managed }}
 network:
   version: 2
   renderer: networkd

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -2,7 +2,7 @@
 {# Copyright (C) 2018-2025 Robert Wimmer
  # SPDX-License-Identifier: GPL-3.0-or-later
  #}
-# {{ ansible_managed }}
+# {{ wireguard__ansible_managed }}
 
 [Interface]
 # {{ inventory_hostname }}


### PR DESCRIPTION
- **OTHER**
  - fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
  - replace `ansible_managed` variable with internal `wireguard__ansible_managed` variable. Reason: `DEFAULT_MANAGED_STR` option is deprecated in Ansible 2.19. The `ansible_managed` variable can be set just like any other variable, or a different variable can be used. At the end for now nothing changes for the user of this role as the output string `Ansible managed` will stay the same.

- **MOLECULE**
  - Molecule: update `netplan` scenario
  - Molecule: update `single-server` scenario