### PR TITLE
19.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 19.1.0
+
+- **OTHER**
+  - update `meta/main.yml`:
+    - remove EL 7/8, Fedora 39/40, Ubuntu 20.04 (focal)
+    - add Debian 13 (trixie), Fedora 43
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx) where possible
+
 ## 19.0.0
 
 - **POTENTIALLY BREAKING**

--- a/README.md
+++ b/README.md
@@ -19,17 +19,21 @@ This role should work with:
 - Ubuntu 22.04 (Jammy Jellyfish)
 - Ubuntu 24.04 (Noble Numbat)
 - Archlinux
-- Debian 11 (Bullseye)
 - Debian 12 (Bookworm)
 - Debian 13 (Trixie)
 - Fedora 42
+- Fedora 43
 - AlmaLinux 9
+- AlmaLinux 10
 - Rocky Linux 9
-- openSUSE Leap
+- Rocky Linux 10
+- openSUSE Leap 15.6
+- openSUSE Leap 16.0
 - Oracle Linux 9
 
 ### Linux - Best effort
 
+- Debian 11 (Bullseye)
 - AlmaLinux 8
 - Rocky Linux 8
 - elementary OS 6
@@ -68,6 +72,16 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 
 **Recent changes:**
 
+## 19.1.0
+
+- **OTHER**
+  - update `meta/main.yml`:
+    - remove EL 7/8, Fedora 39/40, Ubuntu 20.04 (focal)
+    - add Debian 13 (trixie), Fedora 43
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx) where possible
+
 ## 19.0.0
 
 - **POTENTIALLY BREAKING**
@@ -75,52 +89,6 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-wireguard/blob
 
 - **MOLECULE**
   - add Molecule scenario for `wireguard_endpoint` is set to empty [#231](https://github.com/githubixx/ansible-role-wireguard/pull/231)
-
-## 18.3.0
-
-- **OTHER**
-  - Fix for modern PVE installations ([PR #226](https://github.com/githubixx/ansible-role-wireguard/pull/226) - contribution by @pavlozt)
-  - replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
-
-- **FEATURE**
-  - optionally flush handlers at the end of the role via `wireguard_flush_handlers` ([Issue #124](https://github.com/githubixx/ansible-role-wireguard/issues/124))
-
-- **MOLECULE**
-  - replace Vagrant box `alvistack/debian-13` -> `cloud-image/debian-13`
-  - replace Vagrant box `opensuse/Leap-15.6.x86_64` -> `alvistack/opensuse-leap-15.6`
-
-## 18.2.0
-
-- **FEATURE**
-  - add a spoke mode for nodes that should only peer with the hub while keeping the default full-mesh behavior unchanged. See `wireguard_as_spoke` variable and Molecule [spoke-hub](https://github.com/githubixx/ansible-role-wireguard/tree/b85f5842831a02044bd45f0554b9e810688b9148/molecule/spoke-hub) example ([PR #222](https://github.com/githubixx/ansible-role-wireguard/pull/222) - contribution by @eyebrowkang).
-
-## 18.1.0
-
-- **OTHER**
-  - fix issues when running with ansible-core >= 2.19.0 ([Issue #219](https://github.com/githubixx/ansible-role-wireguard/issues/219) / [PR #220](https://github.com/githubixx/ansible-role-wireguard/pull/220/) - contribution by @jonathanplatzer)
-  - replace `ansible_managed` variable with internal `wireguard__ansible_managed` variable. Reason: `DEFAULT_MANAGED_STR` option is deprecated in Ansible 2.19. The `ansible_managed` variable can be set just like any other variable, or a different variable can be used. At the end for now nothing changes for the user of this role as the output string `Ansible managed` will stay the same.
-
-- **MOLECULE**
-  - Molecule: update `netplan` scenario
-  - Molecule: update `single-server` scenario
-
-## 18.0.0
-
-- **BREAKING**
-  - removed support for `CentOS 7` (reached end of life)
-  - removed support for `Ubuntu 20.04` (reached end of life)
-  - removed support for `Fedora 39/40` (reached end of life)
-  - removed support for `openSUSE Leap 15.5` (reached end of life)
-
-- **FEATURE**
-  - add support for `Debian 13` (Trixie)
-  - add support for `Fedora 42`
-
-- **OTHER**
-  - remove unneeded task for `Ubuntu 19.10`
-  - `defaults/main.yml`: add `noqa jinja[spacing]` to ignore `ansible-lint` warning
-  - replace `ansible.builtin.yum` with `ansible.builtin.dnf`
-  - update `.gitignore`
 
 ## Installation
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2018-2025 Robert Wimmer
+# Copyright (C) 2018-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 galaxy_info:
@@ -13,22 +13,21 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "focal"
         - "jammy"
         - "noble"
     - name: Debian
       versions:
         - "bullseye"
         - "bookworm"
+        - "trixie"
     - name: EL
       versions:
-        - "7"
-        - "8"
         - "9"
+        - "10"
     - name: Fedora
       versions:
-        - "39"
-        - "40"
+        - "42"
+        - "43"
     - name: opensuse
       versions:
         - "all"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (C) 2020-2025 Robert Wimmer
-# Copyright (C) 2020-2025 Pierre Ozoux
+# Copyright (C) 2020-2026 Robert Wimmer
+# Copyright (C) 2020-2026 Pierre Ozoux
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:
@@ -13,9 +13,129 @@ driver:
     type: libvirt
 
 platforms:
+  - name: test-wg-arch
+    box: githubixx/archlinux
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.10
+    groups:
+      - vpn
+      - archlinux
+  - name: test-wg-fedora42
+    box: githubixx/fedora-42
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.11
+    groups:
+      - vpn
+      - fedora
+  - name: test-wg-fedora43
+    box: githubixx/fedora-43
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.12
+    groups:
+      - vpn
+      - fedora
+  - name: test-wg-debian11
+    box: generic/debian11
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.13
+    groups:
+      - vpn
+      - debian
+  - name: test-wg-debian12
+    box: githubixx/debian-12
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.14
+    groups:
+      - vpn
+      - debian
   - name: test-wg-debian13
-    box: cloud-image/debian-13
-    memory: 1536
+    box: githubixx/debian-13
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.15
+    groups:
+      - vpn
+      - debian
+  - name: test-wg-opensuse-leap-15-6
+    box: githubixx/opensuse-leap-15.6
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.16
+    groups:
+      - vpn
+      - opensuse
+  - name: test-wg-opensuse-leap-16-0
+    box: githubixx/opensuse-leap-16.0
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.17
+    groups:
+      - vpn
+      - opensuse
+  - name: test-wg-ubuntu2204
+    box: githubixx/ubuntu-22.04
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.18
+    groups:
+      - vpn
+      - ubuntu
+  - name: test-wg-ubuntu2404
+    box: githubixx/ubuntu-24.04
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.19
+    groups:
+      - vpn
+      - ubuntu
+  - name: test-wg-rocky9
+    box: githubixx/rockylinux-9
+    memory: 1228
     cpus: 2
     interfaces:
       - auto_config: true
@@ -24,127 +144,55 @@ platforms:
         ip: 172.16.10.20
     groups:
       - vpn
-      - debian
-  - name: test-wg-fedora42
-    box: alvistack/fedora-42
-    memory: 1536
+      - el
+  - name: test-wg-rocky10
+    box: githubixx/rockylinux-10
+    memory: 1228
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 172.16.10.30
+        ip: 172.16.10.21
     groups:
       - vpn
-      - fedora
-  - name: test-wg-arch
-    box: archlinux/archlinux
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.40
-    groups:
-      - vpn
-      - archlinux
-  - name: test-wg-debian11
-    box: generic/debian11
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.50
-    groups:
-      - vpn
-      - debian
-  - name: test-wg-debian12
-    box: generic/debian12
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.60
-    groups:
-      - vpn
-      - debian
-  - name: test-wg-opensuse-leap-15-6
-    box: alvistack/opensuse-leap-15.6
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.70
-    groups:
-      - vpn
-      - opensuse
-  - name: test-wg-ubuntu2204
-    box: alvistack/ubuntu-22.04
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.110
-    groups:
-      - vpn
-      - ubuntu
-  - name: test-wg-ubuntu2404
-    box: alvistack/ubuntu-24.04
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.120
-    groups:
-      - vpn
-      - ubuntu
-  - name: test-wg-rocky9
-    box: bento/rockylinux-9
-    memory: 1536
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.140
-    groups:
-      - vpn
-      - el9
+      - el
   - name: test-wg-alma9
-    box: almalinux/9
-    memory: 1536
+    box: githubixx/almalinux-9
+    memory: 1228
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 172.16.10.150
+        ip: 172.16.10.22
     groups:
       - vpn
-      - el9
+      - el
+  - name: test-wg-alma10
+    box: githubixx/almalinux-10
+    memory: 1228
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.23
+    groups:
+      - vpn
+      - el
   - name: test-wg-oracle9
     box: generic/oracle9
-    memory: 1536
+    memory: 1228
     cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 172.16.10.160
+        ip: 172.16.10.24
     groups:
       - vpn
-      - el9
+      - el
 
 provisioner:
   name: ansible
@@ -156,70 +204,93 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
+      test-wg-arch:
+        wireguard_address: "10.10.10.10/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.10"
+        ansible_python_interpreter: "/usr/bin/python"
+      test-wg-fedora42:
+        wireguard_address: "10.10.10.11/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.11"
+        wireguard_interface_restart: true
+      test-wg-fedora43:
+        wireguard_address: "10.10.10.12/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.12"
+        wireguard_interface_restart: true
+      test-wg-debian11:
+        wireguard_address: "10.10.10.13/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.13"
+        ansible_python_interpreter: "/usr/bin/python3"
+      test-wg-debian12:
+        wireguard_address: "10.10.10.14/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.14"
+        wireguard_conf_backup: true
+        ansible_python_interpreter: "/usr/bin/python3"
       test-wg-debian13:
+        wireguard_address: "10.10.10.15/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.15"
+        wireguard_interface_restart: true
+      test-wg-opensuse-leap-15-6:
+        wireguard_address: "10.10.10.16/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.16"
+        wireguard_conf_backup: true
+        ansible_python_interpreter: "/usr/bin/python3.11"
+      test-wg-opensuse-leap-16-0:
+        wireguard_address: "10.10.10.17/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.17"
+        wireguard_conf_backup: true
+        ansible_python_interpreter: "/usr/bin/python3.13"
+      test-wg-ubuntu2204:
+        wireguard_address: "10.10.10.18/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.18"
+        wireguard_conf_backup: true
+      test-wg-ubuntu2404:
+        wireguard_address: "10.10.10.19/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.19"
+      test-wg-rocky9:
         wireguard_address: "10.10.10.20/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
         wireguard_endpoint: "172.16.10.20"
-        wireguard_interface_restart: true
-      test-wg-fedora42:
-        wireguard_address: "10.10.10.30/24"
+      test-wg-rocky10:
+        wireguard_address: "10.10.10.21/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.30"
-        wireguard_interface_restart: true
-      test-wg-arch:
-        wireguard_address: "10.10.10.40/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.40"
-        ansible_python_interpreter: "/usr/bin/python"
-      test-wg-debian11:
-        wireguard_address: "10.10.10.50/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.50"
-        ansible_python_interpreter: "/usr/bin/python3"
-      test-wg-debian12:
-        wireguard_address: "10.10.10.60/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.60"
-        wireguard_conf_backup: true
-        ansible_python_interpreter: "/usr/bin/python3"
-      test-wg-opensuse-leap-15-6:
-        wireguard_address: "10.10.10.70/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.70"
-        wireguard_conf_backup: true
-        ansible_python_interpreter: "/usr/bin/python3.9"
-      test-wg-ubuntu2204:
-        wireguard_address: "10.10.10.110/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.110"
-        wireguard_conf_backup: true
-      test-wg-ubuntu2404:
-        wireguard_address: "10.10.10.120/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.120"
-      test-wg-rocky9:
-        wireguard_address: "10.10.10.140/24"
-        wireguard_port: 51820
-        wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.140"
+        wireguard_endpoint: "172.16.10.21"
       test-wg-alma9:
-        wireguard_address: "10.10.10.150/24"
+        wireguard_address: "10.10.10.22/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.150"
+        wireguard_endpoint: "172.16.10.22"
+      test-wg-alma10:
+        wireguard_address: "10.10.10.23/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_endpoint: "172.16.10.23"
       test-wg-oracle9:
-        wireguard_address: "10.10.10.160/24"
+        wireguard_address: "10.10.10.24/24"
         wireguard_port: 51820
         wireguard_persistent_keepalive: "30"
-        wireguard_endpoint: "172.16.10.160"
+        wireguard_endpoint: "172.16.10.24"
 
 scenario:
   name: default


### PR DESCRIPTION
- **OTHER**
  - update `meta/main.yml`:
    - remove EL 7/8, Fedora 39/40, Ubuntu 20.04 (focal)
    - add Debian 13 (trixie), Fedora 43

- **MOLECULE**
  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx) where possible
