### PR TITLE
Add per-pair endpoint selection via wireguard_networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,77 @@ wireguard_unmanaged_peers:
 
 One of `wireguard_address` (deprecated) or `wireguard_addresses` (recommended) is required as already mentioned. It's the IPs of the interface name defined with `wireguard_interface` variable (`wg0` by default). Every host needs at least one unique VPN IP of course. If you don't set `wireguard_endpoint` the playbook will use the hostname defined in the `vpn` hosts group (the Ansible inventory hostname). If you set `wireguard_endpoint` to `""` (empty string) that peer won't have a endpoint. That means that this host can only access hosts that have a `wireguard_endpoint`. That's useful for clients that don't expose any services to the VPN and only want to access services on other hosts. So if you only define one host with `wireguard_endpoint` set and all other hosts have `wireguard_endpoint` set to `""` (empty string) that basically means you've only clients besides one which in that case is the WireGuard server. The third possibility is to set `wireguard_endpoint` to some hostname. E.g. if you have different hostnames for the private and public DNS of that host and need different DNS entries for that case setting `wireguard_endpoint` becomes handy. Take for example the IP above: `wireguard_address: "10.8.0.101"`. That's a private IP and I've created a DNS entry for that private IP like `host01.i.domain.tld` (`i` for internal in that case). For the public IP I've created a DNS entry like `host01.p.domain.tld` (`p` for public). The `wireguard_endpoint` needs to be a interface that the other members in the `vpn` group can connect to. So in that case I would set `wireguard_endpoint` to `host01.p.domain.tld` because WireGuard normally needs to be able to connect to the public IP of the other host(s).
 
+## Per-pair endpoint selection (`wireguard_networks`)
+
+With `wireguard_endpoint` a host has exactly one endpoint and *every* other peer connects to it via that same address. Sometimes you want the endpoint to depend on *which* peer is connecting: hosts that share an internal LAN should talk over that LAN, hosts in different locations should talk over their public IPv4, and a peer that only has IPv6 must be reached over IPv6. `wireguard_networks` lets you express exactly that, without giving up the single flat VPN subnet (the `AllowedIPs` / VPN IPs are unaffected — only the underlay transport changes).
+
+It uses two variables:
+
+- `wireguard_network_priority` — an ordered list of network names, highest preference first. Set it **once and identically for every host** (e.g. in `group_vars/vpn`), because it has to be global for the selection to stay symmetric.
+- `wireguard_networks` — set per host in `host_vars/`. A mapping of network name to the endpoint this host can be reached at on that network. The value is either a plain string (just the endpoint host/IP; this host's own `wireguard_port` is used) or a mapping `{endpoint: ..., port: ...}` when NAT maps an external port to a different `ListenPort`. IPv6 endpoints must be bracketed (`[...]`) and, because of YAML, quoted.
+
+For a link between host A and host B the role uses the peer's endpoint on the **highest-priority network that both A and B list**. Because `wireguard_network_priority` is global, A and B always arrive at the same network, so `A -> B` and `B -> A` use the same path. If two peers share no listed network, selection falls back to the regular `wireguard_endpoint` behaviour described above.
+
+A small example: `host01` and `host02` sit in the same location and share an internal LAN, both also have public IPv4/IPv6, and `host03` is reachable over IPv6 only.
+
+```yaml
+# group_vars/vpn — global, identical on every host, highest preference first
+wireguard_network_priority:
+  - lan
+  - ipv4
+  - ipv6
+```
+
+```yaml
+# host_vars/host01
+wireguard_addresses:
+  - "10.8.0.101/24"
+wireguard_networks:
+  lan: "10.0.0.101"
+  ipv4: "host01.p.domain.tld"
+  ipv6: "[2001:db8::101]"
+```
+
+```yaml
+# host_vars/host02
+wireguard_addresses:
+  - "10.8.0.102/24"
+wireguard_networks:
+  lan: "10.0.0.102"
+  ipv4: "host02.p.domain.tld"
+  ipv6: "[2001:db8::102]"
+```
+
+```yaml
+# host_vars/host03 (IPv6 only)
+wireguard_addresses:
+  - "10.8.0.103/24"
+wireguard_networks:
+  ipv6: "[2001:db8::103]"
+```
+
+`host01` and `host02` both list `lan` (the highest network they share), so they reach each other over the internal LAN; both reach `host03` over IPv6 because that is the only network they share with it. The resulting peer section on `host01` looks like this:
+
+```ini
+[Peer]
+# Name = host02
+PublicKey = ....
+AllowedIPs = 10.8.0.102/32
+Endpoint = 10.0.0.102:51820
+
+[Peer]
+# Name = host03
+PublicKey = ....
+AllowedIPs = 10.8.0.103/32
+Endpoint = [2001:db8::103]:51820
+```
+
+A few things to keep in mind:
+
+- A network name must refer to a transport that all of its members can actually reach each other on. Declaring membership does not create connectivity — if you list two hosts on `ipv4` but there is no IPv4 path between them, that link will be selected and then fail.
+- Only network names listed in `wireguard_network_priority` are considered. A network present in `wireguard_networks` but missing from the priority list is ignored.
+- A host with no `wireguard_networks` (and no `wireguard_endpoint`) is treated as a client with no endpoint, exactly as before.
+
 ## Example
 
 Here is a little example for what I use the playbook: I use WireGuard to setup a fully meshed VPN (every host can directly connect to every other host) and run my Kubernetes (K8s) cluster at Hetzner Cloud (but you should be able to use any hoster you want). So the important components like the K8s controller and worker nodes (which includes the pods) only communicate via encrypted WireGuard VPN. Also (as already mentioned) I've two clients. Both have `kubectl` installed and are able to talk to the internal Kubernetes API server by using WireGuard VPN. One of the two clients also exposes a WireGuard endpoint because the Postfix mailserver in the cloud and my internal Postfix needs to be able to talk to each other. I guess that's maybe a not so common use case for WireGuard :D But it shows what's possible. So let me explain the setup which might help you to use this Ansible role.

--- a/molecule/wireguard-networks/converge.yml
+++ b/molecule/wireguard-networks/converge.yml
@@ -1,0 +1,13 @@
+---
+# Copyright (C) 2026 Eyebrow Kang
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Setup WireGuard
+  hosts: all
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include WireGuard role
+      ansible.builtin.include_role:
+        name: "githubixx.ansible_role_wireguard"

--- a/molecule/wireguard-networks/molecule.yml
+++ b/molecule/wireguard-networks/molecule.yml
@@ -24,7 +24,7 @@ platforms:
     cpus: 1
     interfaces:
       - auto_config: true
-        network_name: public_network
+        network_name: private_network
         type: static
         ip: 192.168.0.10
       - auto_config: true
@@ -40,7 +40,7 @@ platforms:
     cpus: 1
     interfaces:
       - auto_config: true
-        network_name: public_network
+        network_name: private_network
         type: static
         ip: 192.168.0.20
       - auto_config: true
@@ -56,7 +56,7 @@ platforms:
     cpus: 1
     interfaces:
       - auto_config: true
-        network_name: public_network
+        network_name: private_network
         type: static
         ip: 192.168.0.30
     groups:

--- a/molecule/wireguard-networks/molecule.yml
+++ b/molecule/wireguard-networks/molecule.yml
@@ -12,11 +12,11 @@ driver:
     type: libvirt
 
 # node01 and node02 share an internal LAN (172.16.21.0/24) on top of the
-# "public" network (172.16.20.0/24) that all three hosts share. node03 only
+# "public" network (192.168.0.0/24) that all three hosts share. node03 only
 # has the "public" network. With "wireguard_network_priority: [lan, public]"
 # this proves per-pair endpoint selection:
 #   - node01 <-> node02 -> highest shared network "lan"    (172.16.21.x)
-#   - any    <-> node03 -> only shared network    "public" (172.16.20.x)
+#   - any    <-> node03 -> only shared network    "public" (192.168.0.x)
 platforms:
   - name: test-wg-networks-node01
     box: githubixx/ubuntu-24.04
@@ -24,11 +24,11 @@ platforms:
     cpus: 1
     interfaces:
       - auto_config: true
-        network_name: private_network
+        network_name: public_network
         type: static
-        ip: 172.16.20.10
+        ip: 192.168.0.10
       - auto_config: true
-        network_name: wireguard_lan
+        network_name: private_network
         type: static
         ip: 172.16.21.10
     groups:
@@ -40,11 +40,11 @@ platforms:
     cpus: 1
     interfaces:
       - auto_config: true
-        network_name: private_network
+        network_name: public_network
         type: static
-        ip: 172.16.20.20
+        ip: 192.168.0.20
       - auto_config: true
-        network_name: wireguard_lan
+        network_name: private_network
         type: static
         ip: 172.16.21.20
     groups:
@@ -56,9 +56,9 @@ platforms:
     cpus: 1
     interfaces:
       - auto_config: true
-        network_name: private_network
+        network_name: public_network
         type: static
-        ip: 172.16.20.30
+        ip: 192.168.0.30
     groups:
       - vpn
       - ubuntu
@@ -87,14 +87,14 @@ provisioner:
         wireguard_interface_restart: true
         wireguard_networks:
           lan: "172.16.21.10"
-          public: "172.16.20.10"
+          public: "192.168.0.10"
         wireguard_expected_peer_count: 2
         wireguard_expected_peers:
           - test-wg-networks-node02
           - test-wg-networks-node03
         wireguard_expected_endpoints:
           test-wg-networks-node02: "172.16.21.20:51820"
-          test-wg-networks-node03: "172.16.20.30:51820"
+          test-wg-networks-node03: "192.168.0.30:51820"
       test-wg-networks-node02:
         wireguard_addresses:
           - "10.40.0.2/24"
@@ -103,14 +103,14 @@ provisioner:
         wireguard_interface_restart: true
         wireguard_networks:
           lan: "172.16.21.20"
-          public: "172.16.20.20"
+          public: "192.168.0.20"
         wireguard_expected_peer_count: 2
         wireguard_expected_peers:
           - test-wg-networks-node01
           - test-wg-networks-node03
         wireguard_expected_endpoints:
           test-wg-networks-node01: "172.16.21.10:51820"
-          test-wg-networks-node03: "172.16.20.30:51820"
+          test-wg-networks-node03: "192.168.0.30:51820"
       test-wg-networks-node03:
         wireguard_addresses:
           - "10.40.0.3/24"
@@ -118,14 +118,14 @@ provisioner:
         wireguard_persistent_keepalive: "30"
         wireguard_interface_restart: true
         wireguard_networks:
-          public: "172.16.20.30"
+          public: "192.168.0.30"
         wireguard_expected_peer_count: 2
         wireguard_expected_peers:
           - test-wg-networks-node01
           - test-wg-networks-node02
         wireguard_expected_endpoints:
-          test-wg-networks-node01: "172.16.20.10:51820"
-          test-wg-networks-node02: "172.16.20.20:51820"
+          test-wg-networks-node01: "192.168.0.10:51820"
+          test-wg-networks-node02: "192.168.0.20:51820"
 
 scenario:
   name: wireguard-networks

--- a/molecule/wireguard-networks/molecule.yml
+++ b/molecule/wireguard-networks/molecule.yml
@@ -1,0 +1,137 @@
+---
+# Copyright (C) 2026 Eyebrow Kang
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependency:
+  name: galaxy
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+
+# node01 and node02 share an internal LAN (172.16.21.0/24) on top of the
+# "public" network (172.16.20.0/24) that all three hosts share. node03 only
+# has the "public" network. With "wireguard_network_priority: [lan, public]"
+# this proves per-pair endpoint selection:
+#   - node01 <-> node02 -> highest shared network "lan"    (172.16.21.x)
+#   - any    <-> node03 -> only shared network    "public" (172.16.20.x)
+platforms:
+  - name: test-wg-networks-node01
+    box: githubixx/ubuntu-24.04
+    memory: 1024
+    cpus: 1
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.20.10
+      - auto_config: true
+        network_name: wireguard_lan
+        type: static
+        ip: 172.16.21.10
+    groups:
+      - vpn
+      - ubuntu
+  - name: test-wg-networks-node02
+    box: githubixx/ubuntu-24.04
+    memory: 1024
+    cpus: 1
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.20.20
+      - auto_config: true
+        network_name: wireguard_lan
+        type: static
+        ip: 172.16.21.20
+    groups:
+      - vpn
+      - ubuntu
+  - name: test-wg-networks-node03
+    box: githubixx/ubuntu-24.04
+    memory: 1024
+    cpus: 1
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.20.30
+    groups:
+      - vpn
+      - ubuntu
+
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+    ansible_become: true
+  log: true
+  lint:
+    name: ansible-lint
+  inventory:
+    group_vars:
+      vpn:
+        # Global, identical for every host. Highest preference first.
+        wireguard_network_priority:
+          - lan
+          - public
+    host_vars:
+      test-wg-networks-node01:
+        wireguard_addresses:
+          - "10.40.0.1/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_interface_restart: true
+        wireguard_networks:
+          lan: "172.16.21.10"
+          public: "172.16.20.10"
+        wireguard_expected_peer_count: 2
+        wireguard_expected_peers:
+          - test-wg-networks-node02
+          - test-wg-networks-node03
+        wireguard_expected_endpoints:
+          test-wg-networks-node02: "172.16.21.20:51820"
+          test-wg-networks-node03: "172.16.20.30:51820"
+      test-wg-networks-node02:
+        wireguard_addresses:
+          - "10.40.0.2/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_interface_restart: true
+        wireguard_networks:
+          lan: "172.16.21.20"
+          public: "172.16.20.20"
+        wireguard_expected_peer_count: 2
+        wireguard_expected_peers:
+          - test-wg-networks-node01
+          - test-wg-networks-node03
+        wireguard_expected_endpoints:
+          test-wg-networks-node01: "172.16.21.10:51820"
+          test-wg-networks-node03: "172.16.20.30:51820"
+      test-wg-networks-node03:
+        wireguard_addresses:
+          - "10.40.0.3/24"
+        wireguard_port: 51820
+        wireguard_persistent_keepalive: "30"
+        wireguard_interface_restart: true
+        wireguard_networks:
+          public: "172.16.20.30"
+        wireguard_expected_peer_count: 2
+        wireguard_expected_peers:
+          - test-wg-networks-node01
+          - test-wg-networks-node02
+        wireguard_expected_endpoints:
+          test-wg-networks-node01: "172.16.20.10:51820"
+          test-wg-networks-node02: "172.16.20.20:51820"
+
+scenario:
+  name: wireguard-networks
+  test_sequence:
+    - prepare
+    - converge
+
+verifier:
+  name: ansible

--- a/molecule/wireguard-networks/prepare.yml
+++ b/molecule/wireguard-networks/prepare.yml
@@ -1,0 +1,14 @@
+---
+# Copyright (C) 2026 Eyebrow Kang
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Setup Ubuntu hosts
+  hosts: ubuntu
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update APT package cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600

--- a/molecule/wireguard-networks/verify.yml
+++ b/molecule/wireguard-networks/verify.yml
@@ -1,0 +1,76 @@
+---
+# Copyright (C) 2026 Eyebrow Kang
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Verify per-pair endpoint selection (wireguard_networks)
+  hosts: all
+  vars_files:
+    - ../../defaults/main.yml
+  vars:
+    wireguard__config_path: "{{ wireguard_remote_directory }}/{{ wireguard_conf_filename }}"
+  tasks:
+    - name: Count configured WireGuard peers in configuration
+      ansible.builtin.shell: |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+        grep -c '^\[Peer\]' {{ wireguard__config_path }}
+      register: wireguard__peer_count_config
+      args:
+        executable: "/bin/bash"
+      changed_when: false
+
+    - name: Count WireGuard peers from wg tool
+      ansible.builtin.shell: |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+        wg show {{ wireguard_interface }} peers | tr ' ' '\n' | awk 'NF' | wc -l
+      register: wireguard__peer_count_runtime
+      args:
+        executable: "/bin/bash"
+      changed_when: false
+
+    - name: Ensure expected peers are present in configuration
+      ansible.builtin.shell: |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+        grep -F '# Name = {{ item }}' {{ wireguard__config_path }}
+      loop: "{{ wireguard_expected_peers | default([]) }}"
+      args:
+        executable: "/bin/bash"
+      changed_when: false
+
+    - name: Assert peer counts match expectation
+      ansible.builtin.assert:
+        that:
+          - wireguard_expected_peers is defined
+          - wireguard_expected_peer_count is defined
+          - (wireguard_expected_peer_count | int) == (wireguard_expected_peers | default([]) | length)
+          - (wireguard_expected_peer_count | int) == (wireguard__peer_count_config.stdout | int)
+          - (wireguard_expected_peer_count | int) == (wireguard__peer_count_runtime.stdout | int)
+
+    - name: Extract the endpoint selected for each expected peer
+      ansible.builtin.shell: |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+        awk -v name="# Name = {{ item.key }}" '
+          $0 == "[Peer]" {inblock = 0}
+          $0 == name {inblock = 1}
+          inblock && $1 == "Endpoint" {print $3; exit}
+        ' {{ wireguard__config_path }}
+      register: wireguard__selected_endpoints
+      loop: "{{ wireguard_expected_endpoints | default({}) | dict2items }}"
+      args:
+        executable: "/bin/bash"
+      changed_when: false
+      failed_when: wireguard__selected_endpoints.stdout != item.value
+
+    - name: Show selected endpoint per peer
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} -> {{ item.item.key }}: {{ item.stdout }} (expected {{ item.item.value }})"
+      loop: "{{ wireguard__selected_endpoints.results }}"
+      loop_control:
+        label: "{{ item.item.key }}"

--- a/templates/etc/netplan/wg.yaml.j2
+++ b/templates/etc/netplan/wg.yaml.j2
@@ -17,7 +17,7 @@ network:
 {%   endfor %}
 {% endif %}
       key: {{ wireguard_private_key }}
-{% if wireguard_endpoint is not defined or wireguard_endpoint != "" %}
+{% if (wireguard_endpoint is not defined or wireguard_endpoint != "") or (wireguard_networks is defined and wireguard_networks | length > 0) %}
       port: {{ wireguard_port }}
 {% endif %}
 {% if wireguard_mtu is defined %}
@@ -31,7 +31,7 @@ network:
 {% endif %}
       peers:
 {% for host in ansible_play_hosts %}
-{%   if host != inventory_hostname and ((wireguard_as_spoke | default(false)) != true or (hostvars[host].wireguard_as_spoke | default(false)) != true) and ((hostvars[host].wireguard_endpoint is not defined or hostvars[host].wireguard_endpoint != "") or (wireguard_endpoint is not defined or wireguard_endpoint != "")) %}
+{%   if host != inventory_hostname and ((wireguard_as_spoke | default(false)) != true or (hostvars[host].wireguard_as_spoke | default(false)) != true) and ((hostvars[host].wireguard_endpoint is not defined or hostvars[host].wireguard_endpoint != "") or (hostvars[host].wireguard_networks is defined and hostvars[host].wireguard_networks | length > 0) or (wireguard_endpoint is not defined or wireguard_endpoint != "") or (wireguard_networks is defined and wireguard_networks | length > 0)) %}
         - # Name = {{ host }}
           keys:
             public: {{ hostvars[host].wireguard__fact_public_key }}
@@ -57,10 +57,26 @@ network:
 {%         endfor %}
 {%       endif %}
 {%     endif %}
-{%     if hostvars[host].wireguard_persistent_keepalive is defined and (hostvars[host].wireguard_endpoint is not defined or hostvars[host].wireguard_endpoint != "") %}
+{%     if hostvars[host].wireguard_persistent_keepalive is defined and ((hostvars[host].wireguard_endpoint is not defined or hostvars[host].wireguard_endpoint != "") or (hostvars[host].wireguard_networks is defined and hostvars[host].wireguard_networks | length > 0)) %}
           keepalive: {{ hostvars[host].wireguard_persistent_keepalive }}
 {%     endif %}
-{%     if (hostvars[host].wireguard_dc is defined and wireguard_dc is defined and wireguard_dc['name'] != hostvars[host].wireguard_dc['name']) %}
+{%     set wg_ep = namespace(value=none, port=hostvars[host].wireguard_port | default(wireguard_port)) %}
+{%     if wireguard_network_priority is defined and wireguard_networks is defined and hostvars[host].wireguard_networks is defined %}
+{%       for wg_net in wireguard_network_priority %}
+{%         if wg_ep.value is none and wg_net in wireguard_networks and wg_net in hostvars[host].wireguard_networks %}
+{%           set wg_net_def = hostvars[host].wireguard_networks[wg_net] %}
+{%           if wg_net_def is mapping %}
+{%             set wg_ep.value = wg_net_def['endpoint'] %}
+{%             set wg_ep.port = wg_net_def['port'] | default(hostvars[host].wireguard_port | default(wireguard_port)) %}
+{%           else %}
+{%             set wg_ep.value = wg_net_def %}
+{%           endif %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%     if wg_ep.value is not none %}
+          endpoint: "{{ wg_ep.value }}:{{ wg_ep.port }}"
+{%     elif (hostvars[host].wireguard_dc is defined and wireguard_dc is defined and wireguard_dc['name'] != hostvars[host].wireguard_dc['name']) %}
           endpoint: {{ hostvars[host].wireguard_dc['endpoint'] }}:{{ hostvars[host].wireguard_dc['port'] }}
 {%     elif hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "" %}
 {%       if hostvars[host].wireguard_port is defined %}

--- a/templates/etc/wireguard/wg.conf.j2
+++ b/templates/etc/wireguard/wg.conf.j2
@@ -15,7 +15,7 @@ Address = {{ wg_addr }}
 {%  endfor %}
 {% endif %}
 PrivateKey = {{ wireguard_private_key }}
-{% if wireguard_endpoint is defined and wireguard_endpoint != "" %}
+{% if (wireguard_endpoint is defined and wireguard_endpoint != "") or (wireguard_networks is defined and wireguard_networks | length > 0) %}
 ListenPort = {{ wireguard_port }}
 {% endif %}
 {% if wireguard_dns is defined %}
@@ -54,7 +54,7 @@ PostDown = {{ wg_postdown }}
 SaveConfig = {{ wireguard_save_config }}
 {% endif %}
 {% for host in ansible_play_hosts %}
-{%   if host != inventory_hostname and ((wireguard_as_spoke | default(false)) != true or (hostvars[host].wireguard_as_spoke | default(false)) != true) and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (wireguard_endpoint is defined and wireguard_endpoint != "")) %}
+{%   if host != inventory_hostname and ((wireguard_as_spoke | default(false)) != true or (hostvars[host].wireguard_as_spoke | default(false)) != true) and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (hostvars[host].wireguard_networks is defined and hostvars[host].wireguard_networks | length > 0) or (wireguard_endpoint is defined and wireguard_endpoint != "") or (wireguard_networks is defined and wireguard_networks | length > 0)) %}
 
 [Peer]
 # Name = {{ host }}
@@ -75,10 +75,26 @@ AllowedIPs = {{ wg_addr.split('/')[0] }}/128
 {%      endfor %}
 {%      endif %}
 {%     endif %}
-{%     if hostvars[host].wireguard_persistent_keepalive is defined and hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "" %}
+{%     if hostvars[host].wireguard_persistent_keepalive is defined and ((hostvars[host].wireguard_endpoint is defined and hostvars[host].wireguard_endpoint != "") or (hostvars[host].wireguard_networks is defined and hostvars[host].wireguard_networks | length > 0)) %}
 PersistentKeepalive = {{hostvars[host].wireguard_persistent_keepalive}}
 {%     endif %}
-{%     if (
+{%     set wg_ep = namespace(value=none, port=hostvars[host].wireguard_port | default(wireguard_port)) %}
+{%     if wireguard_network_priority is defined and wireguard_networks is defined and hostvars[host].wireguard_networks is defined %}
+{%       for wg_net in wireguard_network_priority %}
+{%         if wg_ep.value is none and wg_net in wireguard_networks and wg_net in hostvars[host].wireguard_networks %}
+{%           set wg_net_def = hostvars[host].wireguard_networks[wg_net] %}
+{%           if wg_net_def is mapping %}
+{%             set wg_ep.value = wg_net_def['endpoint'] %}
+{%             set wg_ep.port = wg_net_def['port'] | default(hostvars[host].wireguard_port | default(wireguard_port)) %}
+{%           else %}
+{%             set wg_ep.value = wg_net_def %}
+{%           endif %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%     if wg_ep.value is not none %}
+Endpoint = {{ wg_ep.value }}:{{ wg_ep.port }}
+{%     elif (
          hostvars[host].wireguard_dc is defined and
          wireguard_dc is defined and
          wireguard_dc['name'] != hostvars[host].wireguard_dc['name']


### PR DESCRIPTION
### TLDR; I added a superset for the hidden `wireguard_dc` feature to solve my situation.

I ran into a topology where a single Endpoint per peer isn't enough, because the best underlay between two hosts depends on which two hosts are talking:

  - A group of my hosts share an internal LAN and should reach each other over that LAN (lowest latency, no public traffic).
  - The same hosts should reach hosts in other locations over public IPv4.
  - One host is IPv6‑only, so everyone has to reach it — and it has to reach everyone — over IPv6.

  What I really need is a preference order of underlays — lan > ipv4 > ipv6 — and for each peer link the role should pick the best underlay the two hosts have in common.

  I found the hidden `wireguard_dc` variable, but it only models two tiers (same‑DC internal endpoint vs. cross‑DC public endpoint). It can't express a three‑tier preference, and the IPv6‑only host doesn't fit the DC grouping at all — so it didn't solve my case.

So I add two new optional variables to solve my case:

  - `wireguard_networks` (per host): a mapping of network name → the endpoint this host is reachable at on that network. The value is either a plain string (endpoint host/IP; the host's own port is used) or {endpoint: ..., port: ...} for NAT port‑remapping.
  - `wireguard_network_priority` (global, e.g. in group_vars): an ordered list of network names, highest preference first.

  For a link between host A and host B, the templates select the peer's endpoint on the highest‑priority network that both A and B list. Because the priority list is global,
  A → B and B → A always agree on the same network, so the link stays symmetric.

Example (group_vars/vpn):
```
  wireguard_network_priority:
    - lan
    - ipv4
    - ipv6

  # host_vars/host01 — internal LAN + dual-stack public
  wireguard_networks:
    lan: "10.0.0.11"
    ipv4: "203.0.113.11"
    ipv6: "[2001:db8::11]"

  # host_vars/host03 — IPv6 only
  wireguard_networks:
    ipv6: "[2001:db8::23]"
```

  Hosts that share lan reach each other over the LAN, reach dual‑stack hosts over ipv4, and reach (and are reached by) the IPv6‑only host over ipv6.

  Of course, it's fully backward compatible. When wireguard_networks / wireguard_network_priority are not set, nothing changes — endpoint selection falls back to the existing wireguard_dc → wireguard_endpoint → inventory‑hostname logic exactly as before.

  ### A note on wireguard_dc

  wireguard_dc effectively becomes a two‑tier special case of wireguard_networks, so in theory it could be removed now. I left it untouched because I'm not sure how widely it's relied on and didn't want to risk breaking anyone — just flagging it in case you'd like to consolidate later.

  ### Testing

  - Added a new Molecule scenario wireguard-networks.
  - Added a dedicated README section documenting both variables.
  - Tested successfully on my own Arch Linux setup and my real world cluster.
